### PR TITLE
Namespace: multi_segment #61

### DIFF
--- a/docs/namespaces/segment.rst
+++ b/docs/namespaces/segment.rst
@@ -125,3 +125,47 @@ The ``value`` field is a string describing the function of the segment.
     30.00 50.000   bridge               null
     50.00 70.000   RefrainA             null
     ===== ======== ==================== ==========
+
+
+multi_segment
+~~~~~~~~~~~~~
+Multi-level structural segmentations.
+
+    ===== ======== ================== ==========
+    time  duration value              confidence
+    ===== ======== ================== ==========
+    [sec] [sec]    * label : string   --
+                   * level : int >= 0
+    ===== ======== ================== ==========
+
+In a multi-level segmentation, the track is partitioned many times --- 
+possibly recursively --- which results in a collection of segmentations of varying degrees
+of specificity.  In the ``multi_segment`` namespace, all of the resulting segments are
+collected together, and the ``level`` field is used to encode the segment's corresponding
+partition.
+
+Level values must be non-negative, and ordered by increasing specificity.  For example,
+``level==0`` may correspond to a single segment spanning the entire track, and each
+subsequent level value corresponds to a more refined segmentation.
+
+*Example*
+    ===== ======== ================== ==========
+    time  duration value              confidence
+    ===== ======== ================== ==========
+    0.000 60.000   * label : A        null
+                   * level : 0
+    0.000 30.000   * label : B        null
+                   * level : 1
+    30.00 60.000   * label : C        null
+                   * level : 1
+    0.000 15.000   * label : a        null
+                   * level : 2
+    15.00 30.000   * label : b        null
+                   * level : 2
+    30.00 45.000   * label : a        null
+                   * level : 2
+    45.00 60.000   * label : c        null
+                   * level : 2
+    ===== ======== ================== ==========
+
+

--- a/jams/schemata/namespaces/segment/multi.json
+++ b/jams/schemata/namespaces/segment/multi.json
@@ -1,0 +1,15 @@
+{"multi_segment":
+    {
+        "value": { 
+            "type": "object",
+            "properties": {
+                "label": {"type": "string" },
+                "level": {"type": "integer", "minimum": 0}
+            },
+            "required": ["label", "level"]
+        },
+        "dense": false,
+        "description": "Multi-level segmentation. Each interval has both a label string and an integer level."
+    }
+}
+

--- a/jams/tests/namespace_tests.py
+++ b/jams/tests/namespace_tests.py
@@ -691,20 +691,22 @@ def test_ns_vector():
 
 def test_ns_multi_segment():
 
-    def __test(label, level):
+    def __test(value):
         ann = Annotation(namespace='multi_segment')
 
-        ann.append(time=0, duration=1, value=dict(label=label, level=level))
+        ann.append(time=0, duration=1, value=value)
 
         ann.validate()
 
     for label in ['a segment', six.u('a unicode segment')]:
+        yield raises(SchemaError)(__test), label
         for level in [0, 1, 2]:
-            yield __test, label, level
+            yield __test, dict(label=label, level=level)
         for level in [-1, None, 'foo']:
-            yield raises(SchemaError)(__test), label, level
+            yield raises(SchemaError)(__test), dict(label=label, level=level)
 
     for label in [23, None]:
+        yield raises(SchemaError)(__test), label
         for level in [0, 1, 2]:
-            yield raises(SchemaError)(__test), label, level
+            yield raises(SchemaError)(__test), dict(label=label, level=level)
 

--- a/jams/tests/namespace_tests.py
+++ b/jams/tests/namespace_tests.py
@@ -687,3 +687,24 @@ def test_ns_vector():
 
     for line in ['a tag', six.u('a unicode tag'), 23, None, dict(), list()]:
         yield raises(SchemaError)(__test), line
+
+
+def test_ns_multi_segment():
+
+    def __test(label, level):
+        ann = Annotation(namespace='multi_segment')
+
+        ann.append(time=0, duration=1, value=dict(label=label, level=level))
+
+        ann.validate()
+
+    for label in ['a segment', six.u('a unicode segment')]:
+        for level in [0, 1, 2]:
+            yield __test, label, level
+        for level in [-1, None, 'foo']:
+            yield raises(SchemaError)(__test), label, level
+
+    for label in [23, None]:
+        for level in [0, 1, 2]:
+            yield raises(SchemaError)(__test), label, level
+


### PR DESCRIPTION
Implements the multi-layer segmentation namespace as described in #61 .

For now, we can hold off on building an eval wrapper for mir_eval until https://github.com/craffel/mir_eval/pull/125 gets merged and released.

Otherwise, this PR is pretty straightforward.