### PR TITLE
implemented object equality search

### DIFF
--- a/jams/tests/jams_test.py
+++ b/jams/tests/jams_test.py
@@ -529,6 +529,8 @@ def test_jams_search():
     yield __test, jam, dict(namespace='beat'), jam.annotations[0:1]
     yield __test, jam, dict(namespace='tag_open'), jam.annotations[1:]
     yield __test, jam, dict(namespace='segment_tut'), jams.AnnotationArray()
+    yield __test, jam.file_metadata, dict(duration=40.0), True
+    yield __test, jam.file_metadata, dict(duration=39.0), False
 
 
 def test_jams_validate_good():

--- a/jams/tests/util_test.py
+++ b/jams/tests/util_test.py
@@ -80,7 +80,8 @@ def test_match_query():
     yield __test, lambda x: True, haystack, True
     yield __test, lambda x: False, haystack, False
 
-    yield raises(jams.ParameterError)(__test), None, haystack, False
+    yield __test, 5, 5, True
+    yield __test, 5, 4, False
 
 
 def test_smkdirs():


### PR DESCRIPTION
Simplifies the search interface for non-string targets.  Created in response to the comments in #70 .
