### PR TITLE
Local namespaces

### DIFF
--- a/docs/namespace_structure.rst
+++ b/docs/namespace_structure.rst
@@ -58,8 +58,16 @@ but dense coding is more space-efficient for high-frequency observations such as
 
 Finally, line 13 contains a brief description of the namespace and corresponding task.
 
+
+Local namespaces
+~~~~~~~~~~~~~~~~
+
 The JAMS namespace management architecture is modular and extensible, so it is relatively straightforward 
 to create a new namespace schema and add it to JAMS at run-time:
 
     >>> jams.schema.add_namespace('/path/to/my/new/namespace.json')
 
+Beginning with JAMS 0.2.1, a custom schema directory can be provided by setting the
+``JAMS_SCHEMA_DIR`` environment variable prior to importing ``jams``.  This allows local
+customizations to be added automatically at run-time without having to manually add each
+schema file individually.

--- a/jams/__init__.py
+++ b/jams/__init__.py
@@ -17,3 +17,11 @@ for _ in util.find_with_extension(resource_filename(__name__, schema.NS_SCHEMA_D
                                   'json'):
     schema.add_namespace(_)
 
+# Populate local namespaces
+import os
+
+try:
+    for _ in util.find_with_extension(os.environ['JAMS_SCHEMA_DIR'], 'json'):
+        schema.add_namespace(_)
+except KeyError:
+    pass

--- a/jams/tests/fixtures/schema/testing_uppercase.json
+++ b/jams/tests/fixtures/schema/testing_uppercase.json
@@ -1,0 +1,7 @@
+{"testing_tag_upper":
+    {
+        "value": { "type": "string", "pattern": "^[A-Z]*$"},
+        "dense": false,
+        "description": "(testing) Upper-case strings only"
+    }
+}

--- a/jams/tests/schema_test.py
+++ b/jams/tests/schema_test.py
@@ -62,9 +62,15 @@ def test_schema_local():
                                                       os.path.join('tests',
                                                                    'fixtures',
                                                                    'schema'))
+
+    # Namespace should not exist yet
+    test_ns = 'testing_tag_upper'
+    yield raises(NamespaceError)(__test), test_ns
+
     reload_module(jams)
 
-    yield __test, 'testing_tag_upper'
+    # Now it should
+    yield __test, test_ns
     
     del os.environ['JAMS_SCHEMA_DIR']
 

--- a/jams/tests/schema_test.py
+++ b/jams/tests/schema_test.py
@@ -4,6 +4,8 @@
 
 from pkg_resources import resource_filename
 
+from six.moves import reload_module
+
 import os
 
 from nose.tools import raises

--- a/jams/tests/schema_test.py
+++ b/jams/tests/schema_test.py
@@ -2,6 +2,10 @@
 #CREATED:2015-07-15 10:21:30 by Brian McFee <brian.mcfee@nyu.edu>
 '''Namespace management tests'''
 
+from pkg_resources import resource_filename
+
+import os
+
 from nose.tools import raises
 from jams import NamespaceError
 import jams
@@ -36,3 +40,29 @@ def test_schema_is_dense():
     yield __test, 'pitch_hz', True
     yield __test, 'beat', False
     yield raises(NamespaceError)(__test), 'made up namespace', False
+
+
+def test_schema_local():
+    def __test(ns_key):
+
+        # Get the schema
+        schema = jams.schema.namespace(ns_key)
+
+        # Make sure it has the correct properties
+        valid_keys = set(['time', 'duration', 'value', 'confidence'])
+        for key in schema['properties']:
+            assert key in valid_keys
+
+        for key in ['time', 'duration']:
+            assert key in schema['properties']
+
+    os.environ['JAMS_SCHEMA_DIR'] = resource_filename(jams.__name__, 
+                                                      os.path.join('tests',
+                                                                   'fixtures',
+                                                                   'schema'))
+    reload(jams)
+
+    yield __test, 'testing_tag_upper'
+    
+    del os.environ['JAMS_SCHEMA_DIR']
+

--- a/jams/tests/schema_test.py
+++ b/jams/tests/schema_test.py
@@ -62,7 +62,7 @@ def test_schema_local():
                                                       os.path.join('tests',
                                                                    'fixtures',
                                                                    'schema'))
-    reload(jams)
+    reload_module(jams)
 
     yield __test, 'testing_tag_upper'
     


### PR DESCRIPTION
This PR implements #55 by allowing the user to specify a path to custom JAMS namespace schema via the environment variable `JAMS_SCHEMA_DIR`.