### PR TITLE
Hierarchical segment evaluation bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
 
 install:
     # install your own package into the environment
+    - pip install --upgrade git+https://github.com/craffel/mir_eval.git
     - pip install -e .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ before_install:
 
 install:
     # install your own package into the environment
-    - pip install --upgrade git+https://github.com/craffel/mir_eval.git
     - pip install -e .
 
 script:

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -35,7 +35,6 @@ if [ ! -d "$src" ]; then
         pip install jsonschema
         pip install python-coveralls
         pip install numpydoc
-        pip install git+https://github.com/craffel/mir_eval.git
 
         source deactivate
     popd

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -35,7 +35,7 @@ if [ ! -d "$src" ]; then
         pip install jsonschema
         pip install python-coveralls
         pip install numpydoc
-        pip install git+https://github.com/craffel/mir_eval.git@develop
+        pip install git+https://github.com/craffel/mir_eval.git
 
         source deactivate
     popd

--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -35,6 +35,7 @@ if [ ! -d "$src" ]; then
         pip install jsonschema
         pip install python-coveralls
         pip install numpydoc
+        pip install git+https://github.com/craffel/mir_eval.git
 
         source deactivate
     popd

--- a/jams/eval.py
+++ b/jams/eval.py
@@ -257,12 +257,12 @@ def hierarchy_flatten(annotation):
         if level not in ordering:
             ordering[level] = dict(intervals=list(), labels=list())
 
-        ordering[level]['interval'].append(interval)
+        ordering[level]['intervals'].append(interval)
         ordering[level]['labels'].append(value['label'])
 
     levels = sorted(list(ordering.keys()))
-    hier_intervals = [ordering[level]['interval'] for level in levels]
-    hier_labels = [ordering[level]['interval'] for level in levels]
+    hier_intervals = [ordering[level]['intervals'] for level in levels]
+    hier_labels = [ordering[level]['labels'] for level in levels]
 
     return hier_intervals, hier_labels
 

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,7 @@ setup(
         'numpy>=1.8.0',
         'six',
         'decorator',
-        #        'mir_eval>=0.2',
-        'mir_eval',
+        'mir_eval>=0.2',
     ],
     scripts=['scripts/jams_to_lab.py']
 )

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'numpy>=1.8.0',
         'six',
         'decorator',
-        'mir_eval',
+        'mir_eval>=0.2',
     ],
     scripts=['scripts/jams_to_lab.py']
 )

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
         'numpy>=1.8.0',
         'six',
         'decorator',
-        'mir_eval>=0.2',
+        #        'mir_eval>=0.2',
+        'mir_eval',
     ],
     scripts=['scripts/jams_to_lab.py']
 )


### PR DESCRIPTION
Implements #72.

Not to be merged until mir_eval hits 0.2.

- [x] conversion from jams `multi_segment` to mir_eval format
- [x] implement eval wrapper
- [x] unit tests
- [x] update version dependency on setup.py
- [x] remove github pip install for mir_eval in travis setup