### PR TITLE
Schemata for the msd tagtraum parser in jams-data.

### DIFF
--- a/docs/namespace_structure.rst
+++ b/docs/namespace_structure.rst
@@ -7,7 +7,7 @@ For example, the `chord` namespace requires that all observed `value` fields are
 pre-defined grammar.  Similarly, the `tempo` namespace requires that `value` fields be non-negative numbers,
 and the `confidence` fields lie within the range `[0, 1]`.
 
-JAMS ships with 24 pre-defined namespaces, covering a variety of common music informatics tasks.  This
+JAMS ships with 26 pre-defined namespaces, covering a variety of common music informatics tasks.  This
 collection should not be assumed to be complete, however, and more namespaces may be added in subsequent
 versions.  Please refer to :ref:`namespace` for a comprehensive description of the existing namespaces.
 

--- a/docs/namespaces/tag.rst
+++ b/docs/namespaces/tag.rst
@@ -85,7 +85,90 @@ by the schema.
     0.000 30.000   "reggae" null
     ===== ======== ======== ==========
 
+tag_msd_tagtraum_cd1
+~~~~~~~~~~~~~~~~~~~~
+Genre classes from the `msd tagtraum cd1`_ dataset.
 
+    ===== ======== ================== ==========
+    time  duration value              confidence
+    ===== ======== ================== ==========
+    [sec] [sec]    string             --
+    ===== ======== ================== ==========
+
+The ``value`` field is constrained to one of 13 strings:
+
+    - ``reggae``
+    - ``pop/rock``
+    - ``rnb``
+    - ``jazz``
+    - ``vocal``
+    - ``new age``
+    - ``latin``
+    - ``rap``
+    - ``country``
+    - ``international``
+    - ``blues``
+    - ``electronic``
+    - ``folk``
+
+.. _msd tagtraum cd1: http://www.tagtraum.com/msd_genre_datasets.html
+
+By convention, one or two tags per track are possible in this namespace.
+The sum of the confidence values should equal ``1.0``.
+This is not enforced by the schema.
+
+
+*Example*
+
+    ===== ======== ======== ==========
+    time  duration value    confidence
+    ===== ======== ======== ==========
+    0.000 0.000    "reggae" 1.0
+    ===== ======== ======== ==========
+
+tag_msd_tagtraum_cd2
+~~~~~~~~~~~~~~~~~~~~
+Genre classes from the `msd tagtraum cd2`_ dataset.
+
+    ===== ======== ================== ==========
+    time  duration value              confidence
+    ===== ======== ================== ==========
+    [sec] [sec]    string             --
+    ===== ======== ================== ==========
+
+The ``value`` field is constrained to one of 15 strings:
+
+    - ``reggae``
+    - ``latin``
+    - ``metal``
+    - ``rnb``
+    - ``jazz``
+    - ``punk``
+    - ``pop``
+    - ``new age``
+    - ``country``
+    - ``rap``
+    - ``rock``
+    - ``world``
+    - ``blues``
+    - ``electronic``
+    - ``folk``
+
+.. _msd tagtraum cd2: http://www.tagtraum.com/msd_genre_datasets.html
+
+By convention, one or two tags per track are possible in this namespace.
+The sum of the confidence values should equal ``1.0``.
+This is not enforced by the schema.
+
+
+*Example*
+
+    ===== ======== ======== ==========
+    time  duration value    confidence
+    ===== ======== ======== ==========
+    0.000 0.000    "reggae" 0.6666667
+    0.000 0.000    "rock"   0.3333333
+    ===== ======== ======== ==========
 
 tag_medleydb_instruments
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/jams/schemata/namespaces/tag/msd_tagtraum_cd1.json
+++ b/jams/schemata/namespaces/tag/msd_tagtraum_cd1.json
@@ -17,6 +17,10 @@
                 "folk"
             ]
         },
+        "confidence": {
+            "oneOf": [ {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                       {"type": "null"} ]
+        },
         "dense": false,
         "description": "msd tagtraum cd1 13-class genre annotation"
     }

--- a/jams/schemata/namespaces/tag/msd_tagtraum_cd1.json
+++ b/jams/schemata/namespaces/tag/msd_tagtraum_cd1.json
@@ -2,19 +2,19 @@
     {
         "value": {
             "enum": [
-                "Reggae",
-                "Pop_Rock",
-                "RnB",
-                "Jazz",
-                "Vocal",
-                "New Age",
-                "Latin",
-                "Rap",
-                "Country",
-                "International",
-                "Blues",
-                "Electronic",
-                "Folk"
+                "reggae",
+                "pop/rock",
+                "rnb",
+                "jazz",
+                "vocal",
+                "new age",
+                "latin",
+                "rap",
+                "country",
+                "international",
+                "blues",
+                "electronic",
+                "folk"
             ]
         },
         "dense": false,

--- a/jams/schemata/namespaces/tag/msd_tagtraum_cd1.json
+++ b/jams/schemata/namespaces/tag/msd_tagtraum_cd1.json
@@ -1,0 +1,23 @@
+{"tag_msd_tagtraum_cd1":
+    {
+        "value": {
+            "enum": [
+                "Reggae",
+                "Pop_Rock",
+                "RnB",
+                "Jazz",
+                "Vocal",
+                "New Age",
+                "Latin",
+                "Rap",
+                "Country",
+                "International",
+                "Blues",
+                "Electronic",
+                "Folk"
+            ]
+        },
+        "dense": false,
+        "description": "msd tagtraum cd1 13-class genre annotation"
+    }
+}

--- a/jams/schemata/namespaces/tag/msd_tagtraum_cd2.json
+++ b/jams/schemata/namespaces/tag/msd_tagtraum_cd2.json
@@ -1,0 +1,25 @@
+{"tag_msd_tagtraum_cd2":
+    {
+        "value": {
+            "enum": [
+                "Reggae",
+                "Latin",
+                "Metal",
+                "RnB",
+                "Jazz",
+                "Punk",
+                "Pop",
+                "New Age",
+                "Country",
+                "Rap",
+                "Rock",
+                "World",
+                "Blues",
+                "Electronic",
+                "Folk"
+            ]
+        },
+        "dense": false,
+        "description": "msd tagtraum cd2 15-class genre annotation"
+    }
+}

--- a/jams/schemata/namespaces/tag/msd_tagtraum_cd2.json
+++ b/jams/schemata/namespaces/tag/msd_tagtraum_cd2.json
@@ -2,21 +2,21 @@
     {
         "value": {
             "enum": [
-                "Reggae",
-                "Latin",
-                "Metal",
-                "RnB",
-                "Jazz",
-                "Punk",
-                "Pop",
-                "New Age",
-                "Country",
-                "Rap",
-                "Rock",
-                "World",
-                "Blues",
-                "Electronic",
-                "Folk"
+                "reggae",
+                "latin",
+                "metal",
+                "rnb",
+                "jazz",
+                "punk",
+                "pop",
+                "new age",
+                "country",
+                "rap",
+                "rock",
+                "world",
+                "blues",
+                "electronic",
+                "folk"
             ]
         },
         "dense": false,

--- a/jams/schemata/namespaces/tag/msd_tagtraum_cd2.json
+++ b/jams/schemata/namespaces/tag/msd_tagtraum_cd2.json
@@ -19,6 +19,10 @@
                 "folk"
             ]
         },
+        "confidence": {
+            "oneOf": [ {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                       {"type": "null"} ]
+        },
         "dense": false,
         "description": "msd tagtraum cd2 15-class genre annotation"
     }

--- a/jams/tests/namespace_tests.py
+++ b/jams/tests/namespace_tests.py
@@ -505,6 +505,71 @@ def test_ns_tag_gtzan():
     for tag in [23, None]:
         yield raises(SchemaError)(__test), tag
 
+def test_ns_tag_msd_tagtraum_cd1():
+
+    def __test(tag):
+        ann = Annotation(namespace='tag_msd_tagtraum_cd1')
+
+        ann.append(time=0, duration=1, value=tag)
+
+        ann.validate()
+
+    for tag in ['reggae',
+                'pop/rock',
+                'rnb',
+                'jazz',
+                'vocal',
+                'new age',
+                'latin',
+                'rap',
+                'country',
+                'international',
+                'blues',
+                'electronic',
+                'folk']:
+
+        yield __test, tag
+        yield __test, six.u(tag)
+        yield raises(SchemaError)(__test), tag.upper()
+
+
+    for tag in [23, None]:
+        yield raises(SchemaError)(__test), tag
+
+
+def test_ns_tag_msd_tagtraum_cd2():
+
+    def __test(tag):
+        ann = Annotation(namespace='tag_msd_tagtraum_cd2')
+
+        ann.append(time=0, duration=1, value=tag)
+
+        ann.validate()
+
+    for tag in ['reggae',
+                'latin',
+                'metal',
+                'rnb',
+                'jazz',
+                'punk',
+                'pop',
+                'new age',
+                'country',
+                'rap',
+                'rock',
+                'world',
+                'blues',
+                'electronic',
+                'folk']:
+
+        yield __test, tag
+        yield __test, six.u(tag)
+        yield raises(SchemaError)(__test), tag.upper()
+
+
+    for tag in [23, None]:
+        yield raises(SchemaError)(__test), tag
+        
 def test_ns_tag_medleydb():
 
     def __test(tag):

--- a/jams/tests/namespace_tests.py
+++ b/jams/tests/namespace_tests.py
@@ -507,10 +507,10 @@ def test_ns_tag_gtzan():
 
 def test_ns_tag_msd_tagtraum_cd1():
 
-    def __test(tag):
+    def __test(tag, confidence=None):
         ann = Annotation(namespace='tag_msd_tagtraum_cd1')
 
-        ann.append(time=0, duration=1, value=tag)
+        ann.append(time=0, duration=1, value=tag, confidence=confidence)
 
         ann.validate()
 
@@ -536,13 +536,18 @@ def test_ns_tag_msd_tagtraum_cd1():
     for tag in [23, None]:
         yield raises(SchemaError)(__test), tag
 
+    yield raises(SchemaError)(__test), 'folk', 1.2
+    yield raises(SchemaError)(__test), 'folk', -0.1
+    yield __test, 'folk', 1.0
+    yield __test, 'folk', 0.0
+
 
 def test_ns_tag_msd_tagtraum_cd2():
 
-    def __test(tag):
+    def __test(tag, confidence=None):
         ann = Annotation(namespace='tag_msd_tagtraum_cd2')
 
-        ann.append(time=0, duration=1, value=tag)
+        ann.append(time=0, duration=1, value=tag, confidence=confidence)
 
         ann.validate()
 
@@ -569,6 +574,12 @@ def test_ns_tag_msd_tagtraum_cd2():
 
     for tag in [23, None]:
         yield raises(SchemaError)(__test), tag
+
+    yield raises(SchemaError)(__test), 'folk', 1.2
+    yield raises(SchemaError)(__test), 'folk', -0.1
+    yield __test, 'folk', 1.0
+    yield __test, 'folk', 0.0
+
         
 def test_ns_tag_medleydb():
 


### PR DESCRIPTION
Hey Bryan,

these are two schemata I need for the simple `msd_tagtraum_cd` dataset support.
I assume no other change is necessary, to have them be found, right?

Cheers,

-hendrik