### PR TITLE
add_observation fails with bad time or duration

### DIFF
--- a/jams/core.py
+++ b/jams/core.py
@@ -675,6 +675,12 @@ class JamsFrame(pd.DataFrame):
         1 00:00:05 00:00:00.500000  C#:min        0.8
         '''
 
+        if time is None or not (time >= 0.0):
+            raise ParameterError('time must be a non-negative number')
+
+        if duration is None or not (duration >= 0.0):
+            raise ParameterError('duration must be a non-negative number')
+
         n = len(self)
         self.loc[n] = {'time': pd.to_timedelta(time, unit='s'),
                        'duration': pd.to_timedelta(duration, unit='s'),

--- a/jams/core.py
+++ b/jams/core.py
@@ -676,10 +676,10 @@ class JamsFrame(pd.DataFrame):
         '''
 
         if time is None or not (time >= 0.0):
-            raise ParameterError('time must be a non-negative number')
+            raise ParameterError('time={} must be a non-negative number'.format(time))
 
         if duration is None or not (duration >= 0.0):
-            raise ParameterError('duration must be a non-negative number')
+            raise ParameterError('duration={} must be a non-negative number'.format(duration))
 
         n = len(self)
         self.loc[n] = {'time': pd.to_timedelta(time, unit='s'),

--- a/jams/tests/eval_test.py
+++ b/jams/tests/eval_test.py
@@ -48,11 +48,6 @@ def test_beat_invalid():
     yield raises(jams.NamespaceError)(jams.eval.beat), ref_ann, est_ann
     yield raises(jams.NamespaceError)(jams.eval.beat), est_ann, ref_ann
 
-    est_ann = create_annotation(values=np.arange(9) % 4 + 1.,
-                                namespace='beat',
-                                offset=-10)
-    yield raises(jams.SchemaError)(jams.eval.beat), ref_ann, est_ann
-    yield raises(jams.SchemaError)(jams.eval.beat), est_ann, ref_ann
 
 # Onset detection
 def test_onset_valid():
@@ -77,12 +72,6 @@ def test_onset_invalid():
 
     yield raises(jams.NamespaceError)(jams.eval.onset), ref_ann, est_ann
     yield raises(jams.NamespaceError)(jams.eval.onset), est_ann, ref_ann
-
-    est_ann = create_annotation(values=np.arange(9) % 4 + 1.,
-                                namespace='onset',
-                                offset=-10)
-    yield raises(jams.SchemaError)(jams.eval.onset), ref_ann, est_ann
-    yield raises(jams.SchemaError)(jams.eval.onset), est_ann, ref_ann
 
 
 # Chord estimation

--- a/jams/tests/jams_test.py
+++ b/jams/tests/jams_test.py
@@ -171,6 +171,22 @@ def test_jamsframe_add_observation():
     eq_(list(jf['confidence']), [0.0, 0.0, 0.0])
 
 
+def test_jamsframe_add_observation_fail():
+
+    @raises(jams.ParameterError)
+    def __test(ann, time, duration, value, confidence):
+        ann.data.add_observation(time=time,
+                                 duration=duration,
+                                 value=value,
+                                 confidence=confidence)
+
+    ann = jams.Annotation(namespace='tag_open')
+
+    yield __test, ann, None, None, 'foo', 1
+    yield __test, ann, 0.0, None, 'foo', 1
+    yield __test, ann, None, 1.0, 'foo', 1
+
+
 def test_jamsframe_interval_values():
 
     df = pd.DataFrame(data=[[0.0, 1.0, 'a', 0.0],

--- a/jams/tests/jams_test.py
+++ b/jams/tests/jams_test.py
@@ -186,6 +186,10 @@ def test_jamsframe_add_observation_fail():
     yield __test, ann, 0.0, None, 'foo', 1
     yield __test, ann, None, 1.0, 'foo', 1
 
+    yield __test, ann, -1, -1, 'foo', 1
+    yield __test, ann, 0.0, -1, 'foo', 1
+    yield __test, ann, -1, 1.0, 'foo', 1
+
 
 def test_jamsframe_interval_values():
 

--- a/jams/tests/namespace_tests.py
+++ b/jams/tests/namespace_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#CREATED:2015-05-26 12:47:35 by Brian McFee <brian.mcfee@nyu.edu>
+# CREATED:2015-05-26 12:47:35 by Brian McFee <brian.mcfee@nyu.edu>
 """Namespace schema tests"""
 
 import six
@@ -9,6 +9,7 @@ from nose.tools import raises
 from jams import SchemaError
 
 from jams import Annotation
+import pandas as pd
 
 
 def test_ns_time_valid():
@@ -26,7 +27,13 @@ def test_ns_time_invalid():
     @raises(SchemaError)
     def __test(data):
         ann = Annotation(namespace='onset')
-        ann.append(**data)
+
+        # Bypass the safety chceks in add_observation
+        ann.data.loc[0] = {'time': pd.to_timedelta(data['time'], unit='s'),
+                           'duration': pd.to_timedelta(data['duration'],
+                                                       unit='s'),
+                           'value': None,
+                           'confdence': None}
 
         ann.validate()
 


### PR DESCRIPTION
Fixes #84 .

`JamsFrame.add_observation` (and, by extension, `Annotation.append`) now fails if time and duration are not provided.