### PR TITLE
fixed a type error in jams_to_lab

### DIFF
--- a/scripts/jams_to_lab.py
+++ b/scripts/jams_to_lab.py
@@ -124,10 +124,10 @@ def convert_jams(jams_file, output_prefix, csv=False, comment_char='#', namespac
     # Make a counter object for each namespace type
     counter = collections.Counter()
 
-    annotations = set()
+    annotations = []
 
     for query in namespaces:
-        annotations.update(jam.search(namespace=query))
+        annotations.extend(jam.search(namespace=query))
 
     if csv:
         suffix = 'csv'

--- a/scripts/jams_to_lab.py
+++ b/scripts/jams_to_lab.py
@@ -112,6 +112,9 @@ def convert_jams(jams_file, output_prefix, csv=False, comment_char='#', namespac
         The set of namespace patterns to match for output
     '''
 
+    if namespaces is None:
+        raise ValueError('No namespaces provided. Try ".*" for all namespaces.')
+
     jam = jams.load(jams_file)
 
     # Get all the annotations


### PR DESCRIPTION
jams_to_lab didn't actually work because ``Annotation`` objects ceased being hashable.

This PR fixes the conversion logic to use an array rather than a set.

Anyone care to CR?  It should be an easy one.  (Maybe @ejhumphrey )