### PR TITLE
added namespace enumerated values accessor

### DIFF
--- a/jams/schema.py
+++ b/jams/schema.py
@@ -10,6 +10,7 @@ Namespace management
     add_namespace
     namespace
     is_dense
+    values
 '''
 
 import json
@@ -91,12 +92,6 @@ def is_dense(ns_key):
 def values(ns_key):
     '''Return the allowed values for an enumerated namespace.
 
-    Example
-    -------
-    >>> values = jams.schema.values('tag_gtzan')
-    ['blues', 'classical', 'country', 'disco', 'hip-hop', ...
-    'jazz', 'metal', 'pop', 'reggae', 'rock']
-
     Parameters
     ----------
     ns_key : str
@@ -110,6 +105,12 @@ def values(ns_key):
     ------
     NamespaceError
         If `ns_key` is not found, or does not have enumerated values
+
+    Examples
+    --------
+    >>> jams.schema.values('tag_gtzan')
+    ['blues', 'classical', 'country', 'disco', 'hip-hop', 'jazz',
+     'metal', 'pop', 'reggae', 'rock']
     '''
 
     if ns_key not in __NAMESPACE__:

--- a/jams/schema.py
+++ b/jams/schema.py
@@ -19,7 +19,7 @@ from pkg_resources import resource_filename
 
 from .exceptions import NamespaceError, JamsError
 
-__all__ = ['add_namespace', 'namespace', 'is_dense']
+__all__ = ['add_namespace', 'namespace', 'is_dense', 'values']
 
 __NAMESPACE__ = dict()
 
@@ -86,6 +86,33 @@ def is_dense(ns_key):
         raise NamespaceError('Unknown namespace: {:s}'.format(ns_key))
 
     return __NAMESPACE__[ns_key]['dense']
+
+
+def values(ns_key):
+    '''Return the allowed values for an enumerated namespace.
+
+    Parameters
+    ----------
+    ns_key : str
+        Namespace key identifier
+
+    Returns
+    -------
+    values : list
+
+    Raises
+    ------
+    NamespaceError
+        If `ns_key` is not found, or does not have enumerated values
+    '''
+
+    if ns_key not in __NAMESPACE__:
+        raise NamespaceError('Unknown namespace: {:s}'.format(ns_key))
+
+    if 'enum' not in __NAMESPACE__[ns_key]['value']:
+        raise NamespaceError('Namespace {:s} is not enumerated'.format(ns_key))
+
+    return copy.copy(__NAMESPACE__[ns_key]['value']['enum'])
 
 
 def __load_jams_schema():

--- a/jams/schema.py
+++ b/jams/schema.py
@@ -91,6 +91,12 @@ def is_dense(ns_key):
 def values(ns_key):
     '''Return the allowed values for an enumerated namespace.
 
+    Example
+    -------
+    >>> values = jams.schema.values('tag_gtzan')
+    ['blues', 'classical', 'country', 'disco', 'hip-hop', ...
+    'jazz', 'metal', 'pop', 'reggae', 'rock']
+
     Parameters
     ----------
     ns_key : str

--- a/jams/tests/schema_test.py
+++ b/jams/tests/schema_test.py
@@ -8,7 +8,7 @@ from six.moves import reload_module
 
 import os
 
-from nose.tools import raises
+from nose.tools import raises, eq_
 from jams import NamespaceError
 import jams
 
@@ -74,3 +74,21 @@ def test_schema_local():
     
     del os.environ['JAMS_SCHEMA_DIR']
 
+
+def test_schema_values_pass():
+
+    values = jams.schema.values('tag_gtzan')
+
+    eq_(values, ['blues', 'classical', 'country',
+                 'disco', 'hip-hop', 'jazz', 'metal',
+                 'pop', 'reggae', 'rock'])
+
+
+@raises(NamespaceError)
+def test_schema_values_missing():
+    jams.schema.values('imaginary namespace')
+
+
+@raises(NamespaceError)
+def test_schema_values_notenum():
+    jams.schema.values('chord_harte')


### PR DESCRIPTION
This PR adds an accessor function for enumerated namespaces (eg, `tag_gtzan`).

Example usage:

```python
>>> values = jams.schema.values('tag_gtzan')
['blues', 'classical', 'country', ...]
```

This is useful for supervised learning tasks, where it's helpful to know the vocabulary up front (eg, for building label encoders).

It only works/makes sense if the namespace's `values` field is an `enum` type.  This rules out things like `tag_open` or `chord`, which are defined by regular expressions (and are, in effect, infinite vocabularies).  If the given namespace is not enumerated, a `NamespaceError` is thrown.  Otherwise, a copy of the values array is returned.

This should be ready for CR.