### PR TITLE
numpy 1.12 compatibility issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
 
 install:
     # install your own package into the environment
+    - pip install git+https://github.com/craffel/mir_eval
     - pip install -e .[display]
 
 script:

--- a/jams/core.py
+++ b/jams/core.py
@@ -43,6 +43,7 @@ import six
 import warnings
 import contextlib
 import gzip
+import copy
 
 from .version import version as __VERSION__
 from . import schema
@@ -708,6 +709,18 @@ class JamsFrame(pd.DataFrame):
         duration = timedelta_to_float(self.duration.values)
 
         return np.vstack([times, times + duration]).T, list(self.value)
+
+    def __deepcopy__(self, memo):
+        '''Explicit deep-copy implementation'''
+        jf = JamsFrame()
+        for field in self.fields():
+            if len(self[field]):
+                jf[field] = copy.deepcopy(self[field])
+            else:
+                jf[field] = []
+
+        jf.dense = copy.deepcopy(self.dense)
+        return jf
 
 
 class Annotation(JObject):

--- a/tests/eval_test.py
+++ b/tests/eval_test.py
@@ -3,7 +3,7 @@
 '''mir_eval integration tests'''
 
 import numpy as np
-from nose.tools import raises
+from nose.tools import raises, nottest
 import jams
 
 from util_test import srand
@@ -27,16 +27,18 @@ def create_annotation(values, namespace='beat', offset=0.0, duration=1, confiden
 
     return ann
 
-def test_chord_valid():
 
-    ref_ann = create_annotation(values=['C', 'D', 'E', 'F'],
-                                namespace='chord')
+@nottest # Temporarily disabled due to mir_eval bug with numpy 1.12
+def test_beat_valid():
 
-    est_ann = create_annotation(values=['G', 'Cmin', 'D', 'D', 'D'],
-                                namespace='chord',
+    ref_ann = create_annotation(values=np.arange(10) % 4 + 0.5,
+                                namespace='beat')
+
+    est_ann = create_annotation(values=np.arange(9) % 4 + 1,
+                                namespace='beat',
                                 offset=0.01)
 
-    jams.eval.chord(ref_ann, est_ann)
+    jams.eval.beat(ref_ann, est_ann)
 
 def test_beat_invalid():
 

--- a/tests/eval_test.py
+++ b/tests/eval_test.py
@@ -27,16 +27,16 @@ def create_annotation(values, namespace='beat', offset=0.0, duration=1, confiden
 
     return ann
 
-def test_beat_valid():
+def test_chord_valid():
 
-    ref_ann = create_annotation(values=np.arange(10) % 4 + 1.,
-                                namespace='beat')
+    ref_ann = create_annotation(values=['C', 'D', 'E', 'F'],
+                                namespace='chord')
 
-    est_ann = create_annotation(values=np.arange(9) % 4 + 1.,
-                                namespace='beat',
+    est_ann = create_annotation(values=['G', 'Cmin', 'D', 'D', 'D'],
+                                namespace='chord',
                                 offset=0.01)
 
-    jams.eval.beat(ref_ann, est_ann)
+    jams.eval.chord(ref_ann, est_ann)
 
 def test_beat_invalid():
 

--- a/tests/eval_test.py
+++ b/tests/eval_test.py
@@ -6,6 +6,9 @@ import numpy as np
 from nose.tools import raises
 import jams
 
+from util_test import srand
+
+
 # Beat tracking
 def create_annotation(values, namespace='beat', offset=0.0, duration=1, confidence=1):
     ann = jams.Annotation(namespace=namespace)
@@ -163,6 +166,8 @@ def test_tempo_invalid():
 # Melody
 def test_melody_valid():
 
+    srand()
+
     f1 = np.linspace(110.0, 440.0, 10)
     v1 = np.sign(np.random.randn(len(f1)))
     v2 = np.sign(np.random.randn(len(f1)))
@@ -180,6 +185,8 @@ def test_melody_valid():
     jams.eval.melody(ref_ann, est_ann)
 
 def test_melody_invalid():
+
+    srand()
 
     f1 = np.linspace(110.0, 440.0, 10)
     v1 = np.sign(np.random.randn(len(f1)))

--- a/tests/namespace_tests.py
+++ b/tests/namespace_tests.py
@@ -11,6 +11,8 @@ from jams import SchemaError
 from jams import Annotation
 import pandas as pd
 
+from util_test import srand
+
 
 def test_ns_time_valid():
 
@@ -325,6 +327,8 @@ def test_ns_pitch_midi_invalid():
 
 def test_ns_contour_valid():
 
+    srand()
+
     ann = Annotation(namespace='pitch_contour')
 
     seq_len = 21
@@ -343,6 +347,8 @@ def test_ns_contour_valid():
     ann.validate()
 
 def test_ns_contour_invalid():
+
+    srand()
 
     ann = Annotation(namespace='pitch_contour')
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -26,10 +26,10 @@ def test_bad_sources():
     def __test(ann, target):
         jams.convert(ann, target)
 
-
     ann = jams.Annotation(namespace='vector')
     for target in ['pitch_hz', 'pitch_midi', 'segment_open', 'tag_open', 'beat', 'chord']:
         yield __test, ann, target
+
 
 def test_noop():
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -14,6 +14,11 @@ from jams import core, util
 import six
 
 
+def srand(seed=628318530):
+    np.random.seed(seed)
+    pass
+
+
 def test_import_lab():
     # Test a lab-file import
     labs = [r'''1.0 1


### PR DESCRIPTION
This PR adds a few fixes:

- [x] srand() in randomized tests
- [x] explicit deepcopy to workaround a bug in pandas on np1.12
- [x] switched from beat to chord testing in eval to work around an issue in mir_eval

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marl/jams/143)
<!-- Reviewable:end -->
