### PR TITLE
added type check in search re.match

### DIFF
--- a/jams/core.py
+++ b/jams/core.py
@@ -1834,7 +1834,7 @@ def match_query(string, query):
     if six.callable(query):
         return query(string)
 
-    elif isinstance(query, six.string_types):
+    elif isinstance(query, six.string_types) and isinstance(string, six.string_types):
         return re.match(query, string) is not None
 
     else:

--- a/tests/jams_test.py
+++ b/tests/jams_test.py
@@ -615,6 +615,8 @@ def test_jams_search():
     fn = 'fixtures/valid.jams'
     jam = jams.load(fn)
 
+    jam.annotations[0].sandbox.foo = None
+
     yield __test, jam, dict(corpus='SMC_MIREX'), jam.annotations
     yield __test, jam, dict(), []
     yield __test, jam, dict(namespace='beat'), jam.annotations[0:1]
@@ -622,6 +624,7 @@ def test_jams_search():
     yield __test, jam, dict(namespace='segment_tut'), jams.AnnotationArray()
     yield __test, jam.file_metadata, dict(duration=40.0), True
     yield __test, jam.file_metadata, dict(duration=39.0), False
+    yield __test, jam, dict(foo='bar'), jams.AnnotationArray()
 
 
 def test_jams_validate_good():


### PR DESCRIPTION
This PR fixes a type error in search when the target field is not a string but the query is.  Originally reported as #145.

New test case was added to cover this issue, so I think this is good to go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marl/jams/146)
<!-- Reviewable:end -->
