### PR TITLE
[CR needed] alternate AnnotationData backend

### DIFF
--- a/docs/examples/example_beat_output.jams
+++ b/docs/examples/example_beat_output.jams
@@ -1,385 +1,835 @@
 {
-  "sandbox": {}, 
+  "sandbox": {},
+  "file_metadata": {
+    "duration": 61.45886621315193,
+    "title": "",
+    "release": "",
+    "identifiers": {},
+    "artist": "",
+    "jams_version": "0.2.3"
+  },
   "annotations": [
     {
-      "namespace": "beat", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": null, 
+      "sandbox": {},
+      "duration": null,
+      "data": [
+        {
+          "value": null,
+          "confidence": null,
+          "time": 0.11609977324263039,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 0.5572789115646258,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 0.9984580498866213,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 1.4628571428571429,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 1.9272562358276644,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 2.391655328798186,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 2.8328344671201813,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 3.297233560090703,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 3.7616326530612243,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 4.2260317460317465,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 4.690430839002268,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 5.154829931972789,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 5.61922902494331,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 6.0836281179138325,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 6.524807256235827,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 6.989206349206349,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 7.453605442176871,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 7.918004535147392,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 8.382403628117913,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 8.870022675736962,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 9.311201814058958,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 9.775600907029478,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 10.24,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 10.704399092970522,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 11.145578231292516,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 11.609977324263038,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 12.07437641723356,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 12.538775510204081,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 13.003174603174603,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 13.467573696145125,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 13.931972789115646,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 14.396371882086168,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 14.837551020408164,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 15.27873015873016,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 15.74312925170068,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 16.207528344671204,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 16.671927437641724,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 17.11310657596372,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 17.600725623582765,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 18.04190476190476,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 18.52952380952381,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 18.970702947845805,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 19.435102040816325,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 19.89950113378685,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 20.36390022675737,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 20.805079365079365,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 21.292698412698414,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 21.73387755102041,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 22.221496598639455,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 22.66267573696145,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 23.127074829931974,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 23.591473922902495,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 24.055873015873015,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 24.49705215419501,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 24.961451247165535,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 25.425850340136055,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 25.913469387755104,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 26.354648526077096,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 26.81904761904762,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 27.28344671201814,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 27.74784580498866,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 28.189024943310656,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 28.65342403628118,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 29.1178231292517,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 29.60544217687075,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 30.06984126984127,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 30.53424036281179,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 30.975419501133786,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 31.43981859410431,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 31.880997732426305,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 32.36861678004535,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 32.833015873015874,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 33.29741496598639,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 33.73859410430839,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 34.202993197278914,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 34.66739229024943,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 35.131791383219955,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 35.57297052154195,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 36.060589569160996,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 36.52498866213152,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 36.989387755102044,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 37.430566893424036,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 37.89496598639456,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 38.35936507936508,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 38.8237641723356,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 39.2649433106576,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 39.75256235827664,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 40.216961451247165,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 40.68136054421769,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 41.12253968253968,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 41.586938775510205,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 42.05133786848072,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 42.515736961451246,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 42.956916099773245,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 43.44453514739229,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 43.885714285714286,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 44.373333333333335,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 44.83773242630385,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 45.302131519274376,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 45.7665306122449,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 46.20770975056689,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 46.672108843537416,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 47.13650793650794,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 47.600907029478456,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 48.06530612244898,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 48.529705215419504,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 48.99410430839002,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 49.458503401360545,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 49.92290249433107,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 50.387301587301586,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 50.85170068027211,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 51.2928798185941,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 51.757278911564626,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 52.22167800453515,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 52.68607709750567,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 53.15047619047619,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 53.614875283446715,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 54.05605442176871,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 54.52045351473923,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 54.98485260770975,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 55.44925170068027,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 55.913650793650795,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 56.37804988662131,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 56.842448979591836,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 57.30684807256236,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 57.77124716553288,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 58.2356462585034,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 58.6768253968254,
+          "duration": 0.0
+        },
+        {
+          "value": null,
+          "confidence": null,
+          "time": 59.14122448979592,
+          "duration": 0.0
+        }
+      ],
+      "namespace": "beat",
+      "time": 0,
       "annotation_metadata": {
-        "annotation_tools": "", 
+        "corpus": "",
+        "validation": "",
+        "annotation_tools": "",
+        "version": "",
         "curator": {
-          "name": "", 
+          "name": "",
           "email": ""
-        }, 
-        "annotator": {}, 
-        "version": "", 
-        "corpus": "", 
-        "annotation_rules": "", 
-        "validation": "", 
+        },
+        "annotation_rules": "",
+        "annotator": {},
         "data_source": "librosa beat tracker"
-      }, 
-      "data": [
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 7.430385
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 8.289524
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 9.218322
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 10.1239
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 11.145578
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 12.190476
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 13.212154
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 14.140952
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 15.27873
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 16.207528
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 17.113107
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 18.041905
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 18.970703
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 19.899501
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 20.805079
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 21.733878
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 22.662676
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 23.591474
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 24.497052
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 25.42585
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 26.354649
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 27.283447
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 28.189025
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 29.117823
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 30.069841
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 30.97542
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 31.880998
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 32.833016
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 33.738594
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 34.667392
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 35.572971
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 36.524989
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 37.453787
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 38.359365
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 39.264942
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 40.216961
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 41.14576
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 42.051338
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 42.956916
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 43.885714
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 44.837732
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 45.97551
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 46.904308
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 47.833107
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 48.761905
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 49.667483
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 50.596281
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 51.525078
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 52.453878
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 53.359456
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 54.288254
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 55.217052
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 56.12263
-        }, 
-        {
-          "duration": 0.0, 
-          "confidence": NaN, 
-          "value": NaN, 
-          "time": 57.051429
-        }
-      ]
-    }, 
+      }
+    },
     {
-      "namespace": "tempo", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 61.45886621315193, 
-      "annotation_metadata": {
-        "annotation_tools": "", 
-        "curator": {
-          "name": "", 
-          "email": ""
-        }, 
-        "annotator": {}, 
-        "version": "", 
-        "corpus": "", 
-        "annotation_rules": "", 
-        "validation": "", 
-        "data_source": "librosa tempo estimator"
-      }, 
+      "sandbox": {},
+      "duration": 61.45886621315193,
       "data": [
         {
-          "duration": 61.458866, 
-          "confidence": 1.0, 
-          "value": 64.599609375, 
-          "time": 0.0
+          "value": 129.19921875,
+          "confidence": 1.0,
+          "time": 0.0,
+          "duration": 61.45886621315193
         }
-      ]
+      ],
+      "namespace": "tempo",
+      "time": 0,
+      "annotation_metadata": {
+        "corpus": "",
+        "validation": "",
+        "annotation_tools": "",
+        "version": "",
+        "curator": {
+          "name": "",
+          "email": ""
+        },
+        "annotation_rules": "",
+        "annotator": {},
+        "data_source": "librosa tempo estimator"
+      }
     }
-  ], 
-  "file_metadata": {
-    "jams_version": "0.2.0", 
-    "title": "", 
-    "identifiers": {}, 
-    "release": "", 
-    "duration": 61.45886621315193, 
-    "artist": ""
-  }
+  ]
 }

--- a/docs/examples/example_chord.jams
+++ b/docs/examples/example_chord.jams
@@ -1,406 +1,406 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "chord", 
-      "sandbox": {}, 
-      "time": 0, 
-      "duration": 175.804082, 
-      "annotation_metadata": {
-        "annotation_tools": "", 
-        "curator": {
-          "name": "", 
-          "email": ""
-        }, 
-        "annotator": {}, 
-        "version": "", 
-        "corpus": "", 
-        "annotation_rules": "", 
-        "validation": "", 
-        "data_source": ""
-      }, 
+      "duration": 175.804082,
       "data": [
         {
-          "duration": 2.612267, 
-          "confidence": 1.0, 
-          "value": "N", 
+          "duration": 2.6122669999999997,
+          "value": "N",
+          "confidence": 1.0,
           "time": 0.0
-        }, 
+        },
         {
-          "duration": 8.846803, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 2.612267
-        }, 
+          "duration": 8.846803000000001,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 2.6122669999999997
+        },
         {
-          "duration": 1.462857, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 1.4628569999999996,
+          "value": "A",
+          "confidence": 1.0,
           "time": 11.45907
-        }, 
+        },
         {
-          "duration": 4.521547, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 4.521546999999998,
+          "value": "E",
+          "confidence": 1.0,
           "time": 12.921927
-        }, 
+        },
         {
-          "duration": 2.966888, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 2.966888000000001,
+          "value": "B",
+          "confidence": 1.0,
           "time": 17.443474
-        }, 
+        },
         {
-          "duration": 1.497687, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 1.497686999999999,
+          "value": "E",
+          "confidence": 1.0,
           "time": 20.410362
-        }, 
+        },
         {
-          "duration": 1.462858, 
-          "confidence": 1.0, 
-          "value": "E:7/3", 
+          "duration": 1.4628580000000007,
+          "value": "E:7/3",
+          "confidence": 1.0,
           "time": 21.908049
-        }, 
+        },
         {
-          "duration": 1.486077, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 1.4860770000000016,
+          "value": "A",
+          "confidence": 1.0,
           "time": 23.370907
-        }, 
+        },
         {
-          "duration": 1.486077, 
-          "confidence": 1.0, 
-          "value": "A:min/b3", 
+          "duration": 1.486076999999998,
+          "value": "A:min/b3",
+          "confidence": 1.0,
           "time": 24.856984
-        }, 
+        },
         {
-          "duration": 1.497687, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 1.497686999999999,
+          "value": "E",
+          "confidence": 1.0,
           "time": 26.343061
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 27.840748
-        }, 
+          "duration": 1.5092970000000037,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 27.840747999999998
+        },
         {
-          "duration": 5.955918, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 5.955917999999997,
+          "value": "E",
+          "confidence": 1.0,
           "time": 29.350045
-        }, 
+        },
         {
-          "duration": 1.497687, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 1.497686999999999,
+          "value": "A",
+          "confidence": 1.0,
           "time": 35.305963
-        }, 
+        },
         {
-          "duration": 4.459452, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 4.459452000000006,
+          "value": "E",
+          "confidence": 1.0,
           "time": 36.80365
-        }, 
+        },
         {
-          "duration": 2.982544, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 2.982543999999997,
+          "value": "B",
+          "confidence": 1.0,
           "time": 41.263102
-        }, 
+        },
         {
-          "duration": 1.474467, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 1.474466999999997,
+          "value": "E",
+          "confidence": 1.0,
           "time": 44.245646
-        }, 
+        },
         {
-          "duration": 1.486077, 
-          "confidence": 1.0, 
-          "value": "E:7/3", 
+          "duration": 1.4860770000000016,
+          "value": "E:7/3",
+          "confidence": 1.0,
           "time": 45.720113
-        }, 
+        },
         {
-          "duration": 1.486077, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 1.4860770000000016,
+          "value": "A",
+          "confidence": 1.0,
           "time": 47.20619
-        }, 
+        },
         {
-          "duration": 1.462857, 
-          "confidence": 1.0, 
-          "value": "A:min/b3", 
+          "duration": 1.4628569999999996,
+          "value": "A:min/b3",
+          "confidence": 1.0,
           "time": 48.692267
-        }, 
+        },
         {
-          "duration": 1.497687, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 1.497686999999999,
+          "value": "E",
+          "confidence": 1.0,
           "time": 50.155124
-        }, 
+        },
         {
-          "duration": 1.486077, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 1.4860770000000016,
+          "value": "B",
+          "confidence": 1.0,
           "time": 51.652811
-        }, 
+        },
         {
-          "duration": 2.972155, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 2.9721550000000008,
+          "value": "E",
+          "confidence": 1.0,
           "time": 53.138888
-        }, 
+        },
         {
-          "duration": 9.020952, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 9.020951999999987,
+          "value": "A",
+          "confidence": 1.0,
           "time": 56.111043
-        }, 
+        },
         {
-          "duration": 3.018594, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 65.131995
-        }, 
+          "duration": 3.0185940000000073,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 65.13199499999999
+        },
         {
-          "duration": 3.041814, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 3.0418140000000022,
+          "value": "A",
+          "confidence": 1.0,
           "time": 68.150589
-        }, 
+        },
         {
-          "duration": 3.006984, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 3.0069840000000028,
+          "value": "E",
+          "confidence": 1.0,
           "time": 71.192403
-        }, 
+        },
         {
-          "duration": 1.497687, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 1.497686999999999,
+          "value": "A",
+          "confidence": 1.0,
           "time": 74.199387
-        }, 
+        },
         {
-          "duration": 4.539501, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 4.539501000000001,
+          "value": "E",
+          "confidence": 1.0,
           "time": 75.697074
-        }, 
+        },
         {
-          "duration": 2.972155, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 2.9721550000000008,
+          "value": "B",
+          "confidence": 1.0,
           "time": 80.236575
-        }, 
+        },
         {
-          "duration": 3.012963, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 3.012962999999999,
+          "value": "E",
+          "confidence": 1.0,
           "time": 83.20873
-        }, 
+        },
         {
-          "duration": 1.514928, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 1.5149279999999976,
+          "value": "A",
+          "confidence": 1.0,
           "time": 86.221693
-        }, 
+        },
         {
-          "duration": 1.520907, 
-          "confidence": 1.0, 
-          "value": "A:min/b3", 
+          "duration": 1.5209070000000082,
+          "value": "A:min/b3",
+          "confidence": 1.0,
           "time": 87.736621
-        }, 
+        },
         {
-          "duration": 1.462857, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 89.257527
-        }, 
+          "duration": 1.4628569999999854,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 89.25752800000001
+        },
         {
-          "duration": 1.437068, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 1.4370680000000107,
+          "value": "B",
+          "confidence": 1.0,
           "time": 90.720385
-        }, 
+        },
         {
-          "duration": 11.949236, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 11.949235999999999,
+          "value": "E",
+          "confidence": 1.0,
           "time": 92.157453
-        }, 
+        },
         {
-          "duration": 3.018594, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 3.0185940000000073,
+          "value": "B",
+          "confidence": 1.0,
           "time": 104.106689
-        }, 
+        },
         {
-          "duration": 3.053424, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 107.125283
-        }, 
+          "duration": 3.0534239999999926,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 107.12528300000001
+        },
         {
-          "duration": 2.94538, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 2.9453800000000143,
+          "value": "A",
+          "confidence": 1.0,
           "time": 110.178707
-        }, 
+        },
         {
-          "duration": 1.489631, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 113.124087
-        }, 
+          "duration": 1.4896309999999744,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 113.12408700000002
+        },
         {
-          "duration": 1.486077, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 114.613718
-        }, 
+          "duration": 1.4860770000000088,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 114.61371799999999
+        },
         {
-          "duration": 2.845166, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 2.845166000000006,
+          "value": "E",
+          "confidence": 1.0,
           "time": 116.099795
-        }, 
+        },
         {
-          "duration": 9.101501, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 9.101501000000013,
+          "value": "A",
+          "confidence": 1.0,
           "time": 118.944961
-        }, 
+        },
         {
-          "duration": 3.006984, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 128.046462
-        }, 
+          "duration": 3.0069839999999886,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 128.04646200000002
+        },
         {
-          "duration": 2.983764, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 2.983764000000008,
+          "value": "A",
+          "confidence": 1.0,
           "time": 131.053446
-        }, 
+        },
         {
-          "duration": 3.006985, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 134.03721
-        }, 
+          "duration": 3.006984999999986,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 134.03721000000002
+        },
         {
-          "duration": 1.431329, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 1.4313290000000052,
+          "value": "A",
+          "confidence": 1.0,
           "time": 137.044195
-        }, 
+        },
         {
-          "duration": 4.582639, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 4.582638999999972,
+          "value": "E",
+          "confidence": 1.0,
           "time": 138.475524
-        }, 
+        },
         {
-          "duration": 2.983764, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 143.058163
-        }, 
+          "duration": 2.9837640000000363,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 143.05816299999998
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "E", 
-          "time": 146.041927
-        }, 
+          "duration": 1.5092969999999752,
+          "value": "E",
+          "confidence": 1.0,
+          "time": 146.04192700000002
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "E:7/3", 
+          "duration": 1.5092970000000037,
+          "value": "E:7/3",
+          "confidence": 1.0,
           "time": 147.551224
-        }, 
+        },
         {
-          "duration": 1.451247, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 1.451246999999995,
+          "value": "A",
+          "confidence": 1.0,
           "time": 149.060521
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "A:min/b3", 
+          "duration": 1.5092970000000037,
+          "value": "A:min/b3",
+          "confidence": 1.0,
           "time": 150.511768
-        }, 
+        },
         {
-          "duration": 1.509297, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 1.509297000000032,
+          "value": "E",
+          "confidence": 1.0,
           "time": 152.021065
-        }, 
+        },
         {
-          "duration": 1.532517, 
-          "confidence": 1.0, 
-          "value": "B", 
-          "time": 153.530362
-        }, 
+          "duration": 1.5325169999999844,
+          "value": "B",
+          "confidence": 1.0,
+          "time": 153.53036200000003
+        },
         {
-          "duration": 4.469842, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 4.469842,
+          "value": "E",
+          "confidence": 1.0,
           "time": 155.062879
-        }, 
+        },
         {
-          "duration": 1.532517, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 1.5325169999999844,
+          "value": "B",
+          "confidence": 1.0,
           "time": 159.532721
-        }, 
+        },
         {
-          "duration": 4.516281, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 4.516280999999992,
+          "value": "E",
+          "confidence": 1.0,
           "time": 161.065238
-        }, 
+        },
         {
-          "duration": 1.532517, 
-          "confidence": 1.0, 
-          "value": "B", 
+          "duration": 1.5325170000000128,
+          "value": "B",
+          "confidence": 1.0,
           "time": 165.581519
-        }, 
+        },
         {
-          "duration": 1.532517, 
-          "confidence": 1.0, 
-          "value": "A", 
+          "duration": 1.5325170000000128,
+          "value": "A",
+          "confidence": 1.0,
           "time": 167.114036
-        }, 
+        },
         {
-          "duration": 1.090856, 
-          "confidence": 1.0, 
-          "value": "E", 
+          "duration": 1.0908560000000023,
+          "value": "E",
+          "confidence": 1.0,
           "time": 168.646553
-        }, 
+        },
         {
-          "duration": 1.949764, 
-          "confidence": 1.0, 
-          "value": "E:9", 
+          "duration": 1.9497639999999876,
+          "value": "E:9",
+          "confidence": 1.0,
           "time": 169.737409
-        }, 
+        },
         {
-          "duration": 4.116909, 
-          "confidence": 1.0, 
-          "value": "N", 
+          "duration": 4.116908999999993,
+          "value": "N",
+          "confidence": 1.0,
           "time": 171.687173
         }
-      ]
+      ],
+      "namespace": "chord",
+      "time": 0,
+      "annotation_metadata": {
+        "version": "",
+        "annotation_tools": "",
+        "annotator": {},
+        "curator": {
+          "email": "",
+          "name": ""
+        },
+        "data_source": "",
+        "corpus": "",
+        "annotation_rules": "",
+        "validation": ""
+      },
+      "sandbox": {}
     }
-  ], 
+  ],
   "file_metadata": {
-    "jams_version": "0.2.0", 
-    "title": "", 
-    "identifiers": {}, 
-    "release": "", 
-    "duration": 175.804082, 
-    "artist": ""
-  }
+    "duration": 175.804082,
+    "jams_version": "0.2.3",
+    "artist": "",
+    "identifiers": {},
+    "release": "",
+    "title": ""
+  },
+  "sandbox": {}
 }

--- a/docs/examples/example_chord_import.py
+++ b/docs/examples/example_chord_import.py
@@ -3,6 +3,7 @@
 import jams
 import sys
 
+
 def import_chord_jams(infile, outfile):
 
     # import_lab returns a new jams object,
@@ -10,14 +11,12 @@ def import_chord_jams(infile, outfile):
     jam, chords = jams.util.import_lab('chord', infile)
 
     # Infer the track duration from the end of the last annotation
-    duration = (chords.data['time'] + chords.data['duration']).max()
+    duration = max([obs.time + obs.duration for obs in chords])
 
-    # this timing will be in pandas timedelta.
-    # calling duration.total_seconds() converts to float
-    jam.file_metadata.duration = duration.total_seconds()
+    jam.file_metadata.duration = duration
 
     chords.time = 0
-    chords.duration = duration.total_seconds()
+    chords.duration = duration
 
     # save to disk
     jam.save(outfile)
@@ -27,4 +26,3 @@ if __name__ == '__main__':
 
     infile, outfile = sys.argv[1:]
     import_chord_jams(infile, outfile)
-

--- a/jams/__init__.py
+++ b/jams/__init__.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 """Top-level module for JAMS"""
 
+import os
+from pkg_resources import resource_filename
+
 # Import the necessary modules
 from .exceptions import *
 from . import util
@@ -12,15 +15,13 @@ from .version import version as __version__
 from .core import *
 from .nsconvert import convert
 
-# Populate the namespace mapping
-from pkg_resources import resource_filename
 
+# Populate the namespace mapping
 for _ in util.find_with_extension(resource_filename(__name__, schema.NS_SCHEMA_DIR),
                                   'json'):
     schema.add_namespace(_)
 
 # Populate local namespaces
-import os
 
 try:
     for _ in util.find_with_extension(os.environ['JAMS_SCHEMA_DIR'], 'json'):

--- a/jams/core.py
+++ b/jams/core.py
@@ -775,10 +775,11 @@ class AnnotationData(object):
 
     def append_columns(self, columns):
 
-        self.append_records(six.moves.zip(columns['time'],
-                                          columns['duration'],
-                                          columns['value'],
-                                          columns['confidence']))
+        self.append_records([dict(time=t, duration=d, value=v, confidence=c)
+                             for t,d,v,c in six.moves.zip(columns['time'],
+                                                          columns['duration'],
+                                                          columns['value'],
+                                                          columns['confidence'])])
 
     def to_interval_values(self):
         '''Extract observation data in a `mir_eval`-friendly format.
@@ -832,6 +833,9 @@ class AnnotationData(object):
     def __repr__(self):
         return '<{}: {:d} observations>'.format(self.__class__.__name__,
                                                 len(self))
+
+    def __iter__(self):
+        return iter(self.obs)
 
 
 class Annotation(JObject):

--- a/jams/core.py
+++ b/jams/core.py
@@ -39,6 +39,7 @@ from collections import namedtuple
 from sortedcontainers import SortedListWithKey
 
 import numpy as np
+import pandas as pd
 import os
 import re
 import six
@@ -572,6 +573,11 @@ class AnnotationData(object):
             vals.append(obs.value)
 
         return np.array(ints), vals
+
+    def to_dataframe(self):
+        return pd.DataFrame.from_records(list(self.obs),
+                                         columns=['time', 'duration',
+                                                  'value', 'confidence'])
 
     @property
     def __json__(self):

--- a/jams/core.py
+++ b/jams/core.py
@@ -1021,7 +1021,8 @@ class Annotation(JObject):
         -------
         df : pd.DataFrame
             Columns are `time, duration, value, confidence`.
-            Each row is an observation.
+            Each row is an observation, and rows are sorted by
+            ascending `time`.
         '''
         return pd.DataFrame.from_records(list(self.data),
                                          columns=['time', 'duration',

--- a/jams/core.py
+++ b/jams/core.py
@@ -533,11 +533,8 @@ class AnnotationData(object):
 
     def add_observation(self, time=None, duration=None, value=None,
                         confidence=None):
-        idx = self.obs.bisect_key(time)
-        self.obs.insert(idx, Observation(time=time,
-                                         duration=duration,
-                                         value=value,
-                                         confidence=confidence))
+        self.obs.add(Observation(time=time, duration=duration,
+                                 value=value, confidence=confidence))
 
     def append_records(self, records):
 

--- a/jams/core.py
+++ b/jams/core.py
@@ -980,11 +980,15 @@ class Annotation(JObject):
                                          columns=['time', 'duration',
                                                   'value', 'confidence'])
 
+    # Collection methods
     def __len__(self):
         return len(self.data)
 
     def __iter__(self):
         return iter(self.data)
+
+    def __contains__(self, item):
+        return item in self.data
 
     def to_html(self):
         '''Render this annotation list in HTML
@@ -1063,6 +1067,9 @@ class Annotation(JObject):
 
     @classmethod
     def _key(cls, obs):
+        if not isinstance(obs, Observation):
+            raise JamsError('{} must be of type jams.Observation'.format(obs))
+
         return obs.time
 
 

--- a/jams/core.py
+++ b/jams/core.py
@@ -581,7 +581,6 @@ class Annotation(JObject):
         >>> ann.append(time=3, duration=2, value='E#')
         '''
 
-        # TODO: validate time and duration here
         self.data.add(Observation(time=time,
                                   duration=duration,
                                   value=value,

--- a/jams/core.py
+++ b/jams/core.py
@@ -613,6 +613,7 @@ class AnnotationData(object):
         return iter(self.obs)
 
 
+
 class Annotation(JObject):
     """Annotation base class."""
 
@@ -998,9 +999,7 @@ class Annotation(JObject):
         '''
         # start by trimming the annotation
         sliced_ann = self.trim(start_time, end_time, strict=strict)
-        raw_data = sliced_ann.data
-        sliced_ann.data = AnnotationData()
-        sliced_ann.data.dense = raw_data.dense
+        raw_data = sliced_ann.pop_data()
 
         # now adjust the start time of the annotation and the observations it
         # contains.
@@ -1030,6 +1029,21 @@ class Annotation(JObject):
                  'slice_start': slice_start, 'slice_end': slice_end})
 
         return sliced_ann
+
+    def pop_data(self):
+        '''Replace this observation's data with a fresh AnnotationData
+        object.
+
+        Returns
+        -------
+        annotation_data : jams.AnnotationData
+            The original annotation data object
+        '''
+
+        data = self.data
+        self.data = AnnotationData()
+        self.data.dense = data.dense
+        return data
 
 
 class Curator(JObject):

--- a/jams/core.py
+++ b/jams/core.py
@@ -33,22 +33,19 @@ Object reference
 """
 
 import json
-import jsonschema
 from collections import namedtuple
-from sortedcontainers import SortedListWithKey
 
-import numpy as np
-import pandas as pd
 import os
 import re
-import six
 import warnings
 import contextlib
 import gzip
+import six
 
-import copy
-import sys
-
+import numpy as np
+import pandas as pd
+import jsonschema
+from sortedcontainers import SortedListWithKey
 from decorator import decorator
 
 from .version import version as __VERSION__
@@ -61,6 +58,7 @@ __all__ = ['load',
            'Annotation', 'Curator', 'AnnotationMetadata',
            'FileMetadata', 'AnnotationArray', 'JAMS',
            'Observation']
+
 
 def deprecated(version, version_removed):
     '''This is a decorator which can be used to mark functions
@@ -145,11 +143,13 @@ def _open(name_or_fdesc, mode='r', fmt='auto'):
                 yield fdesc
 
         except KeyError:
-            raise ParameterError('Unknown JAMS extension format: "{:s}"'.format(ext))
+            raise ParameterError('Unknown JAMS extension '
+                                 'format: "{:s}"'.format(ext))
 
     else:
         # Don't know how to handle this. Raise a parameter error
-        raise ParameterError('Invalid filename or descriptor: {}'.format(name_or_fdesc))
+        raise ParameterError('Invalid filename or '
+                             'descriptor: {}'.format(name_or_fdesc))
 
 
 def load(path_or_file, validate=True, strict=True, fmt='auto'):
@@ -432,7 +432,8 @@ class JObject(object):
         -------
         match : bool
             `True` if any of the search keys match the specified value,
-            `False` otherwise, or if the search keys do not exist within the object.
+            `False` otherwise, or if the search keys do not exist
+            within the object.
 
         Examples
         --------
@@ -579,7 +580,6 @@ class Annotation(JObject):
             else:
                 self.append_records(data)
 
-
         if sandbox is None:
             sandbox = Sandbox()
 
@@ -663,7 +663,8 @@ class Annotation(JObject):
         -------
         valid : bool
             `True` if the object conforms to schema.
-            `False` if the object fails to conform to schema, but `strict == False`.
+            `False` if the object fails to conform to schema,
+            but `strict == False`.
 
         Raises
         ------
@@ -790,9 +791,9 @@ class Annotation(JObject):
             orig_time = start_time
             orig_duration = end_time - start_time
             warnings.warn(
-                "Annotation.duration is not defined, cannot check for temporal "
-                "intersection, assuming the annotation is valid between "
-                "start_time and end_time.")
+                "Annotation.duration is not defined, cannot check "
+                "for temporal intersection, assuming the annotation "
+                "is valid between start_time and end_time.")
         else:
             orig_time = self.time
             orig_duration = self.duration
@@ -962,7 +963,6 @@ class Annotation(JObject):
 
         return sliced_ann
 
-
     def pop_data(self):
         '''Replace this observation's data with a fresh container.
 
@@ -1053,7 +1053,7 @@ class Annotation(JObject):
                         </tr>
                     </thead>'''
         out += r'''<tbody>'''
-        for i, o in enumerate(self.data):
+        for i, obs in enumerate(self.data):
             out += r'''<tr>
                             <th>{:d}</th>
                             <td>{:0.6f}</td>
@@ -1061,14 +1061,15 @@ class Annotation(JObject):
                             <td>{:}</td>
                             <td>{:}</td>
                         </tr>'''.format(i,
-                                        o.time,
-                                        o.duration,
-                                        o.value,
-                                        o.confidence)
+                                        obs.time,
+                                        obs.duration,
+                                        obs.value,
+                                        obs.confidence)
         out += r'''</tbody></table>'''
         return out
 
     def _repr_html_(self):
+        '''Render annotation as HTML.  See also: `to_html()`'''
         return self.to_html()
 
     @property
@@ -1111,6 +1112,7 @@ class Annotation(JObject):
 
     @classmethod
     def _key(cls, obs):
+        '''Provides sorting index for Observation objects'''
         if not isinstance(obs, Observation):
             raise JamsError('{} must be of type jams.Observation'.format(obs))
 
@@ -1248,7 +1250,8 @@ class AnnotationArray(list):
     are supported:
 
     - integer or slice : acts just as in `list`, e.g., `arr[0]` or `arr[1:3]`
-    - string : acts like a search, e.g., `arr['beat'] == arr.search(namespace='beat')`
+    - string : acts like a search, e.g.,
+      `arr['beat'] == arr.search(namespace='beat')`
     - (string, integer or slice) acts like a search followed by index/slice
 
     Examples
@@ -1733,13 +1736,6 @@ class JAMS(JObject):
 
 
 # -- Helper functions -- #
-
-def timedelta_to_float(t):
-    '''Convert a timedelta64[ns] to floating point (seconds)'''
-
-    return t.astype(np.float) * 1e-9
-
-
 def query_pop(query, prefix, sep='.'):
     '''Pop a prefix from a query string.
 
@@ -1804,7 +1800,8 @@ def match_query(string, query):
     if six.callable(query):
         return query(string)
 
-    elif isinstance(query, six.string_types) and isinstance(string, six.string_types):
+    elif (isinstance(query, six.string_types) and
+          isinstance(string, six.string_types)):
         return re.match(query, string) is not None
 
     else:
@@ -1829,5 +1826,3 @@ def serialize_obj(obj):
         return {k: serialize_obj(v) for k, v in six.iteritems(obj._asdict())}
 
     return obj
-
-

--- a/jams/core.py
+++ b/jams/core.py
@@ -771,15 +771,19 @@ class AnnotationData(object):
     def append_records(self, records):
 
         for obs in records:
-            self.add_observation(**obs)
+            if isinstance(obs, Observation):
+                self.add_observation(**obs._asdict())
+            else:
+                self.add_observation(**obs)
 
     def append_columns(self, columns):
 
         self.append_records([dict(time=t, duration=d, value=v, confidence=c)
-                             for t,d,v,c in six.moves.zip(columns['time'],
-                                                          columns['duration'],
-                                                          columns['value'],
-                                                          columns['confidence'])])
+                             for (t, d, v, c)
+                             in six.moves.zip(columns['time'],
+                                              columns['duration'],
+                                              columns['value'],
+                                              columns['confidence'])])
 
     def to_interval_values(self):
         '''Extract observation data in a `mir_eval`-friendly format.

--- a/jams/core.py
+++ b/jams/core.py
@@ -810,7 +810,7 @@ class AnnotationData(object):
             for (t, d, v, c) in self.obs:
                 times.append(t)
                 durations.append(d)
-                values.append(v)
+                values.append(serialize_obj(v))
                 confidences.append(c)
 
             return dict(time=times,
@@ -820,7 +820,7 @@ class AnnotationData(object):
         else:
             return [dict(time=o.time,
                          duration=o.duration,
-                         value=o.value,
+                         value=serialize_obj(o.value),
                          confidence=o.confidence) for o in self.obs]
 
     def __len__(self):

--- a/jams/core.py
+++ b/jams/core.py
@@ -987,9 +987,6 @@ class Annotation(JObject):
     def __iter__(self):
         return iter(self.data)
 
-    def __contains__(self, item):
-        return item in self.data
-
     def to_html(self):
         '''Render this annotation list in HTML
 

--- a/jams/core.py
+++ b/jams/core.py
@@ -967,6 +967,24 @@ class Annotation(JObject):
 
         return np.array(ints), vals
 
+    def to_event_values(self):
+        '''Extract observation data in a `mir_eval`-friendly format.
+
+        Returns
+        -------
+        times : np.ndarray [shape=(n,), dtype=float]
+            Start-time of all observations
+
+        labels : list
+            List view of value field.
+        '''
+        ints, vals = [], []
+        for obs in self.data:
+            ints.append(obs.time)
+            vals.append(obs.value)
+
+        return np.array(ints), vals
+
     def to_dataframe(self):
         '''Convert this annotation to a pandas dataframe.
 

--- a/jams/core.py
+++ b/jams/core.py
@@ -843,7 +843,6 @@ class Annotation(JObject):
                                        value=obs.value,
                                        confidence=obs.confidence)
 
-        ann_trimmed.data.reset_index(drop=True, inplace=True)
         if 'trim' not in ann_trimmed.sandbox.keys():
             ann_trimmed.sandbox.update(
                 trim=[{'start_time': start_time, 'end_time': end_time,

--- a/jams/core.py
+++ b/jams/core.py
@@ -995,6 +995,9 @@ class Annotation(JObject):
             ints.append([obs.time, obs.time + obs.duration])
             vals.append(obs.value)
 
+        if not ints:
+            return np.empty(shape=(0, 2), dtype=float), []
+
         return np.array(ints), vals
 
     def to_event_values(self):

--- a/jams/core.py
+++ b/jams/core.py
@@ -980,10 +980,6 @@ class Annotation(JObject):
                                          columns=['time', 'duration',
                                                   'value', 'confidence'])
 
-    # Collection methods
-    def __len__(self):
-        return len(self.data)
-
     def __iter__(self):
         return iter(self.data)
 

--- a/jams/core.py
+++ b/jams/core.py
@@ -149,7 +149,7 @@ def _open(name_or_fdesc, mode='r', fmt='auto'):
 
     else:
         # Don't know how to handle this. Raise a parameter error
-        raise ParameterError('Invalid filename or descriptor: {:r}'.format(name_or_fdesc))
+        raise ParameterError('Invalid filename or descriptor: {}'.format(name_or_fdesc))
 
 
 def load(path_or_file, validate=True, strict=True, fmt='auto'):

--- a/jams/core.py
+++ b/jams/core.py
@@ -766,19 +766,17 @@ class Annotation(JObject):
         >>> ann_trim = ann.trim(5, 8, strict=False)
         >>> print(ann_trim.time, ann_trim.duration)
         (5, 3)
-        >>> ann_trim.data
-              time  duration  value confidence
-        0 00:00:05  00:00:01    two       None
-        1 00:00:06  00:00:02  three       None
-        2 00:00:07  00:00:01   four       None
-        >>>
+        >>> ann_trim.to_dataframe()
+           time  duration  value confidence
+        0     5         1    two       None
+        1     6         2  three       None
+        2     7         1   four       None
         >>> ann_trim_strict = ann.trim(5, 8, strict=True)
         >>> print(ann_trim_strict.time, ann_trim_strict.duration)
         (5, 3)
         >>> ann_trim_strict.data
-              time  duration  value confidence
-        0 00:00:06  00:00:02  three       None
-
+           time  duration  value confidence
+        0     6         2  three       None
         '''
         # Check for basic start_time and end_time validity
         if end_time <= start_time:
@@ -917,18 +915,16 @@ class Annotation(JObject):
         >>> print(ann_slice.time, ann_slice.duration)
         (0, 3)
         >>> ann_slice.data
-              time  duration  value confidence
-        0 00:00:00  00:00:01    two       None
-        1 00:00:01  00:00:02  three       None
-        2 00:00:02  00:00:01   four       None
-        >>>
+           time  duration  value confidence
+        0     0         1    two       None
+        1     1         2  three       None
+        2     2         1   four       None
         >>> ann_slice_strict = ann.slice(5, 8, strict=True)
         >>> print(ann_slice_strict.time, ann_slice_strict.duration)
         (0, 3)
         >>> ann_slice_strict.data
-              time  duration  value confidence
-        0 00:00:01  00:00:02  three       None
-
+           time  duration  value confidence
+        0     1         2  three       None
         '''
         # start by trimming the annotation
         sliced_ann = self.trim(start_time, end_time, strict=strict)

--- a/jams/display.py
+++ b/jams/display.py
@@ -63,7 +63,7 @@ def pprint_jobject(obj, **kwargs):
 
 def intervals(annotation, **kwargs):
     '''Plotting wrapper for labeled intervals'''
-    times, labels = annotation.data.to_interval_values()
+    times, labels = annotation.to_interval_values()
 
     return mir_eval.display.labeled_intervals(times, labels, **kwargs)
 
@@ -83,7 +83,7 @@ def pitch_contour(annotation, **kwargs):
     # If the annotation is empty, we need to construct a new axes
     ax = mir_eval.display.__get_axes(ax=ax)[0]
 
-    times, values = annotation.data.to_interval_values()
+    times, values = annotation.to_interval_values()
 
     indices = np.unique([v['index'] for v in values])
 
@@ -102,7 +102,7 @@ def pitch_contour(annotation, **kwargs):
 def event(annotation, **kwargs):
     '''Plotting wrapper for events'''
 
-    times, values = annotation.data.to_interval_values()
+    times, values = annotation.to_interval_values()
 
     if any(values):
         labels = values
@@ -115,7 +115,7 @@ def event(annotation, **kwargs):
 def beat_position(annotation, **kwargs):
     '''Plotting wrapper for beat-position data'''
 
-    times, values = annotation.data.to_interval_values()
+    times, values = annotation.to_interval_values()
 
     labels = [_['position'] for _ in values]
 
@@ -125,7 +125,7 @@ def beat_position(annotation, **kwargs):
 
 def piano_roll(annotation, **kwargs):
     '''Plotting wrapper for piano rolls'''
-    times, midi = annotation.data.to_interval_values()
+    times, midi = annotation.to_interval_values()
 
     return mir_eval.display.piano_roll(times, midi=midi, **kwargs)
 

--- a/jams/display.py
+++ b/jams/display.py
@@ -88,7 +88,7 @@ def pitch_contour(annotation, **kwargs):
     indices = np.unique([v['index'] for v in values])
 
     for idx in indices:
-        rows = annotation.data.value.apply(lambda x: x['index'] == idx).nonzero()[0]
+        rows = [i for (i, v) in enumerate(values) if v['index'] == idx]
         freqs = np.asarray([values[r]['frequency'] for r in rows])
         unvoiced = ~np.asarray([values[r]['voiced'] for r in rows])
         freqs[unvoiced] *= -1

--- a/jams/eval.py
+++ b/jams/eval.py
@@ -106,10 +106,10 @@ def beat(ref, est, **kwargs):
     namespace = 'beat'
     ref = coerce_annotation(ref, namespace)
     est = coerce_annotation(est, namespace)
-    ref_interval, _ = ref.to_interval_values()
-    est_interval, _ = est.to_interval_values()
+    ref_times, _ = ref.to_event_values()
+    est_times, _ = est.to_event_values()
 
-    return mir_eval.beat.evaluate(ref_interval[:, 0], est_interval[:, 0], **kwargs)
+    return mir_eval.beat.evaluate(ref_times, est_times, **kwargs)
 
 
 def onset(ref, est, **kwargs):
@@ -147,10 +147,10 @@ def onset(ref, est, **kwargs):
     namespace = 'onset'
     ref = coerce_annotation(ref, namespace)
     est = coerce_annotation(est, namespace)
-    ref_interval, _ = ref.to_interval_values()
-    est_interval, _ = est.to_interval_values()
+    ref_times, _ = ref.to_event_values()
+    est_times, _ = est.to_event_values()
 
-    return mir_eval.onset.evaluate(ref_interval[:, 0], est_interval[:, 0], **kwargs)
+    return mir_eval.onset.evaluate(ref_times, est_times, **kwargs)
 
 
 def chord(ref, est, **kwargs):
@@ -396,14 +396,14 @@ def melody(ref, est, **kwargs):
     namespace = 'pitch_contour'
     ref = coerce_annotation(ref, namespace)
     est = coerce_annotation(est, namespace)
-    ref_interval, ref_p = ref.to_interval_values()
-    est_interval, est_p = est.to_interval_values()
+    ref_times, ref_p = ref.to_event_values()
+    est_times, est_p = est.to_event_values()
 
     ref_freq = np.asarray([p['frequency'] * (-1)**(~p['voiced']) for p in ref_p])
     est_freq = np.asarray([p['frequency'] * (-1)**(~p['voiced']) for p in est_p])
 
-    return mir_eval.melody.evaluate(ref_interval[:, 0], ref_freq,
-                                    est_interval[:, 0], est_freq,
+    return mir_eval.melody.evaluate(ref_times, ref_freq,
+                                    est_times, est_freq,
                                     **kwargs)
 
 

--- a/jams/eval.py
+++ b/jams/eval.py
@@ -26,7 +26,9 @@ import mir_eval
 
 from .nsconvert import convert
 
-__all__ = ['beat', 'chord', 'melody', 'onset', 'segment', 'hierarchy', 'tempo', 'pattern', 'transcription']
+__all__ = ['beat', 'chord', 'melody', 'onset',
+           'segment', 'hierarchy', 'tempo',
+           'pattern', 'transcription']
 
 
 def coerce_annotation(ann, namespace):
@@ -350,11 +352,12 @@ def tempo(ref, est, **kwargs):
 
     ref = coerce_annotation(ref, 'tempo')
     est = coerce_annotation(est, 'tempo')
-    ref_tempi = ref.data['value'].values
-    ref_weight = ref.data['confidence'][0]
-    est_tempi = est.data['value'].values
+    ref_tempi = np.asarray([o.value for o in ref.data])
+    ref_weight = ref.data.obs[0].confidence
+    est_tempi = np.asarray([o.value for o in est.data])
 
     return mir_eval.tempo.evaluate(ref_tempi, ref_weight, est_tempi, **kwargs)
+
 
 # melody
 def melody(ref, est, **kwargs):

--- a/jams/eval.py
+++ b/jams/eval.py
@@ -106,8 +106,8 @@ def beat(ref, est, **kwargs):
     namespace = 'beat'
     ref = coerce_annotation(ref, namespace)
     est = coerce_annotation(est, namespace)
-    ref_interval, _ = ref.data.to_interval_values()
-    est_interval, _ = est.data.to_interval_values()
+    ref_interval, _ = ref.to_interval_values()
+    est_interval, _ = est.to_interval_values()
 
     return mir_eval.beat.evaluate(ref_interval[:, 0], est_interval[:, 0], **kwargs)
 
@@ -147,8 +147,8 @@ def onset(ref, est, **kwargs):
     namespace = 'onset'
     ref = coerce_annotation(ref, namespace)
     est = coerce_annotation(est, namespace)
-    ref_interval, _ = ref.data.to_interval_values()
-    est_interval, _ = est.data.to_interval_values()
+    ref_interval, _ = ref.to_interval_values()
+    est_interval, _ = est.to_interval_values()
 
     return mir_eval.onset.evaluate(ref_interval[:, 0], est_interval[:, 0], **kwargs)
 
@@ -189,8 +189,8 @@ def chord(ref, est, **kwargs):
     namespace = 'chord'
     ref = coerce_annotation(ref, namespace)
     est = coerce_annotation(est, namespace)
-    ref_interval, ref_value = ref.data.to_interval_values()
-    est_interval, est_value = est.data.to_interval_values()
+    ref_interval, ref_value = ref.to_interval_values()
+    est_interval, est_value = est.to_interval_values()
 
     return mir_eval.chord.evaluate(ref_interval, ref_value,
                                    est_interval, est_value, **kwargs)
@@ -231,8 +231,8 @@ def segment(ref, est, **kwargs):
     namespace = 'segment_open'
     ref = coerce_annotation(ref, namespace)
     est = coerce_annotation(est, namespace)
-    ref_interval, ref_value = ref.data.to_interval_values()
-    est_interval, est_value = est.data.to_interval_values()
+    ref_interval, ref_value = ref.to_interval_values()
+    est_interval, est_value = est.to_interval_values()
 
     return mir_eval.segment.evaluate(ref_interval, ref_value,
                                      est_interval, est_value, **kwargs)
@@ -255,7 +255,7 @@ def hierarchy_flatten(annotation):
         A list of lists of labels, ordered by increasing specificity.
     '''
 
-    intervals, values = annotation.data.to_interval_values()
+    intervals, values = annotation.to_interval_values()
 
     ordering = dict()
 
@@ -352,9 +352,9 @@ def tempo(ref, est, **kwargs):
 
     ref = coerce_annotation(ref, 'tempo')
     est = coerce_annotation(est, 'tempo')
-    ref_tempi = np.asarray([o.value for o in ref.data])
-    ref_weight = ref.data.obs[0].confidence
-    est_tempi = np.asarray([o.value for o in est.data])
+    ref_tempi = np.asarray([o.value for o in ref])
+    ref_weight = ref.data[0].confidence
+    est_tempi = np.asarray([o.value for o in est])
 
     return mir_eval.tempo.evaluate(ref_tempi, ref_weight, est_tempi, **kwargs)
 
@@ -396,8 +396,8 @@ def melody(ref, est, **kwargs):
     namespace = 'pitch_contour'
     ref = coerce_annotation(ref, namespace)
     est = coerce_annotation(est, namespace)
-    ref_interval, ref_p = ref.data.to_interval_values()
-    est_interval, est_p = est.data.to_interval_values()
+    ref_interval, ref_p = ref.to_interval_values()
+    est_interval, est_p = est.to_interval_values()
 
     ref_freq = np.asarray([p['frequency'] * (-1)**(~p['voiced']) for p in ref_p])
     est_freq = np.asarray([p['frequency'] * (-1)**(~p['voiced']) for p in est_p])
@@ -434,7 +434,7 @@ def pattern_to_mireval(ann):
     patterns = defaultdict(lambda: defaultdict(list))
 
     # Iterate over the data in interval-value format
-    for interval, observation in zip(*ann.data.to_interval_values()):
+    for interval, observation in zip(*ann.to_interval_values()):
 
         pattern_id = observation['pattern_id']
         occurrence_id = observation['occurrence_id']
@@ -527,8 +527,8 @@ def transcription(ref, est, **kwargs):
     namespace = 'pitch_contour'
     ref = coerce_annotation(ref, namespace)
     est = coerce_annotation(est, namespace)
-    ref_intervals, ref_p = ref.data.to_interval_values()
-    est_intervals, est_p = est.data.to_interval_values()
+    ref_intervals, ref_p = ref.to_interval_values()
+    est_intervals, est_p = est.to_interval_values()
 
     ref_pitches = np.asarray([p['frequency'] * (-1)**(~p['voiced']) for p in ref_p])
     est_pitches = np.asarray([p['frequency'] * (-1)**(~p['voiced']) for p in est_p])

--- a/jams/eval.py
+++ b/jams/eval.py
@@ -434,11 +434,11 @@ def pattern_to_mireval(ann):
     patterns = defaultdict(lambda: defaultdict(list))
 
     # Iterate over the data in interval-value format
-    for interval, observation in zip(*ann.to_interval_values()):
+    for time, observation in zip(*ann.to_event_values()):
 
         pattern_id = observation['pattern_id']
         occurrence_id = observation['occurrence_id']
-        obs = (interval[0], observation['midi_pitch'])
+        obs = (time, observation['midi_pitch'])
 
         # Push this note observation into the correct pattern/occurrence
         patterns[pattern_id][occurrence_id].append(obs)

--- a/jams/exceptions.py
+++ b/jams/exceptions.py
@@ -2,6 +2,7 @@
 # -*- encoding: utf-8 -*-
 '''Exception classes for JAMS'''
 
+
 class JamsError(Exception):
     '''The root JAMS exception class'''
     pass
@@ -11,9 +12,11 @@ class SchemaError(JamsError):
     '''Exceptions relating to schema validation'''
     pass
 
+
 class NamespaceError(JamsError):
     '''Exceptions relating to task namespaces'''
     pass
+
 
 class ParameterError(JamsError):
     '''Exceptions relating to function and method parameters'''

--- a/jams/nsconvert.py
+++ b/jams/nsconvert.py
@@ -16,8 +16,6 @@ import numpy as np
 from copy import deepcopy
 from collections import defaultdict
 
-from .core import AnnotationData
-
 from .exceptions import NamespaceError
 
 

--- a/jams/nsconvert.py
+++ b/jams/nsconvert.py
@@ -140,31 +140,11 @@ def can_convert(annotation, target_namespace):
     return False
 
 
-def pop_data(annotation):
-    '''Replace an annotation's observation data with a fresh AnnotationData
-    object.
-
-    Parameters
-    ----------
-    annotation : jams.Annotation
-
-    Returns
-    -------
-    annotation_data : jams.AnnotationData
-        The original annotation data object
-    '''
-
-    data = annotation.data
-    annotation.data = AnnotationData()
-    annotation.data.dense = data.dense
-    return data
-
-
 @_conversion('pitch_contour', 'pitch_hz')
 def pitch_hz_to_contour(annotation):
     '''Convert a pitch_hz annotation to a contour'''
     annotation.namespace = 'pitch_contour'
-    data = pop_data(annotation)
+    data = annotation.pop_data()
 
     for obs in data:
         annotation.append(time=obs.time, duration=obs.duration,
@@ -187,7 +167,7 @@ def note_midi_to_hz(annotation):
     '''Convert a pitch_midi annotation to pitch_hz'''
 
     annotation.namespace = 'note_hz'
-    data = pop_data(annotation)
+    data = annotation.pop_data()
 
     for obs in data:
         annotation.append(time=obs.time, duration=obs.duration,
@@ -203,7 +183,7 @@ def note_hz_to_midi(annotation):
 
     annotation.namespace = 'note_midi'
 
-    data = pop_data(annotation)
+    data = annotation.pop_data()
 
     for obs in data:
         annotation.append(time=obs.time, duration=obs.duration,
@@ -219,7 +199,7 @@ def pitch_midi_to_hz(annotation):
 
     annotation.namespace = 'pitch_hz'
 
-    data = pop_data(annotation)
+    data = annotation.pop_data()
 
     for obs in data:
         annotation.append(time=obs.time, duration=obs.duration,
@@ -234,7 +214,7 @@ def pitch_hz_to_midi(annotation):
     '''Convert a pitch_hz annotation to pitch_midi'''
 
     annotation.namespace = 'pitch_midi'
-    data = pop_data(annotation)
+    data = annotation.pop_data()
 
     for obs in data:
         annotation.append(time=obs.time, duration=obs.duration,
@@ -264,7 +244,7 @@ def beat_position(annotation):
     '''Convert beat_position to beat'''
 
     annotation.namespace = 'beat'
-    data = pop_data(annotation)
+    data = annotation.pop_data()
     for obs in data:
         annotation.append(time=obs.time, duration=obs.duration,
                           confidence=obs.confidence,

--- a/jams/nsconvert.py
+++ b/jams/nsconvert.py
@@ -68,7 +68,7 @@ def convert(annotation, target_namespace):
     ------
     SchemaError
         if the input annotation fails to validate
-    
+
     NamespaceError
         if no conversion is possible
 
@@ -180,7 +180,6 @@ def note_hz_to_midi(annotation):
     '''Convert a pitch_hz annotation to pitch_midi'''
 
     annotation.namespace = 'note_midi'
-
 
     data = annotation.pop_data()
 

--- a/jams/schema.py
+++ b/jams/schema.py
@@ -126,7 +126,8 @@ def values(ns_key):
 
 
 def get_dtypes(ns_key):
-    '''Get the dtypes associated with the value and confidence fields for a given schema.
+    '''Get the dtypes associated with the value and confidence fields
+    for a given namespace.
 
     Parameters
     ----------
@@ -136,7 +137,7 @@ def get_dtypes(ns_key):
     Returns
     -------
     value_dtype, confidence_dtype : numpy.dtype
-        Type identifiers for dataframe/jamsframe columns.
+        Type identifiers for value and confidence fields.
     '''
 
     # First, get the schema

--- a/jams/sonify.py
+++ b/jams/sonify.py
@@ -133,7 +133,7 @@ def pitch_contour(annotation, sr=22050, length=None, **kwargs):
 
     y_out = 0.0
     for ix in indices:
-        rows = annotation.data.value.apply(lambda x: x['index'] == ix).nonzero()[0]
+        rows = [i for (i, v) in enumerate(values) if v['index'] == ix]
 
         freqs = np.asarray([values[r]['frequency'] for r in rows])
         unv = ~np.asarray([values[r]['voiced'] for r in rows])

--- a/jams/sonify.py
+++ b/jams/sonify.py
@@ -43,7 +43,7 @@ def clicks(annotation, sr=22050, length=None, **kwargs):
     events such as beats or segment boundaries.
     '''
 
-    interval, _ = annotation.data.to_interval_values()
+    interval, _ = annotation.to_interval_values()
 
     return filter_kwargs(mir_eval.sonify.clicks, interval[:, 0],
                          fs=sr, length=length, **kwargs)
@@ -56,7 +56,7 @@ def downbeat(annotation, sr=22050, length=None, **kwargs):
     beat_click = mkclick(440 * 2, sr=sr)
     downbeat_click = mkclick(440 * 3, sr=sr)
 
-    intervals, values = annotation.data.to_interval_values()
+    intervals, values = annotation.to_interval_values()
 
     beats, downbeats = [], []
 
@@ -109,7 +109,7 @@ def chord(annotation, sr=22050, length=None, **kwargs):
     This uses mir_eval.sonify.chords.
     '''
 
-    intervals, chords = annotation.data.to_interval_values()
+    intervals, chords = annotation.to_interval_values()
 
     return filter_kwargs(mir_eval.sonify.chords,
                          chords, intervals,
@@ -127,7 +127,7 @@ def pitch_contour(annotation, sr=22050, length=None, **kwargs):
     are summed together.
     '''
 
-    times, values = annotation.data.to_interval_values()
+    times, values = annotation.to_interval_values()
 
     indices = np.unique([v['index'] for v in values])
 
@@ -153,13 +153,13 @@ def pitch_contour(annotation, sr=22050, length=None, **kwargs):
 
 def piano_roll(annotation, sr=22050, length=None, **kwargs):
     '''Sonify a piano-roll
-    
+
     This uses mir_eval.sonify.time_frequency, and is appropriate
     for sparse transcription data, e.g., annotations in the `note_midi`
     namespace.
     '''
 
-    intervals, pitches = annotation.data.to_interval_values()
+    intervals, pitches = annotation.to_interval_values()
 
     # Construct the pitchogram
     pitch_map = {f: idx for idx, f in enumerate(np.unique(pitches))}

--- a/jams/util.py
+++ b/jams/util.py
@@ -115,10 +115,10 @@ def import_lab(namespace, filename, jam=None, infer_duration=True, **parse_optio
 
         value = [x for x in row[3:] if x is not None][-1]
 
-        annotation.data.add_observation(time=time,
-                                        duration=duration,
-                                        confidence=1.0,
-                                        value=value)
+        annotation.append(time=time,
+                          duration=duration,
+                          confidence=1.0,
+                          value=value)
 
     jam.annotations.append(annotation)
 

--- a/jams/util.py
+++ b/jams/util.py
@@ -12,7 +12,6 @@ Utility functions
     smkdirs
     filebase
     find_with_extension
-    _deprecated
 """
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,13 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
     keywords='audio music json',
     license='ISC',
     install_requires=[
         'pandas',
+        'sortedcontainers',
         'jsonschema',
         'numpy>=1.8.0',
         'six',

--- a/tests/eval_test.py
+++ b/tests/eval_test.py
@@ -3,7 +3,7 @@
 '''mir_eval integration tests'''
 
 import numpy as np
-from nose.tools import raises, nottest
+from nose.tools import raises
 import jams
 
 from util_test import srand
@@ -28,7 +28,6 @@ def create_annotation(values, namespace='beat', offset=0.0, duration=1, confiden
     return ann
 
 
-@nottest # Temporarily disabled due to mir_eval bug with numpy 1.12
 def test_beat_valid():
 
     ref_ann = create_annotation(values=np.arange(10) % 4 + 0.5,

--- a/tests/eval_test.py
+++ b/tests/eval_test.py
@@ -188,7 +188,6 @@ def test_melody_valid():
 
 # Temporarily disabling because pandas 0.20 won't allow us to
 # construct ill-typed observations
-@nottest
 def test_melody_invalid():
 
     srand()
@@ -307,7 +306,6 @@ def test_transcription_valid():
 
 # Temporarily disabled because pandas 0.20 will not allow unsafe type mixtures,
 # so there's no easy way to make a bad corner case
-@nottest
 def test_transcription_invalid():
 
     ref_jam = jams.load('fixtures/transcription_ref.jams')

--- a/tests/jams_test.py
+++ b/tests/jams_test.py
@@ -10,6 +10,7 @@ import six
 import sys
 import warnings
 
+import numpy as np
 from nose.tools import raises, eq_
 try:
     import pandas.testing as pdt

--- a/tests/jams_test.py
+++ b/tests/jams_test.py
@@ -189,7 +189,6 @@ def test_annotation():
             eq_(dict(sandbox), dict(ann.sandbox))
 
         if data is not None:
-            eq_(len(ann), len(data))
             eq_(len(ann.data), len(data))
             for obs1, obs2 in zip(ann.data, data):
                 eq_(obs1._asdict(), obs2)
@@ -246,6 +245,14 @@ def test_annotation_eq():
     ann2.append(**update)
 
     assert not (ann1 == ann2)
+
+
+@raises(jams.JamsError)
+def test_annotation_badtype():
+
+    an = jams.Annotation(namespace='tag_open')
+    # This should throw a jams error because NoneType can't be indexed
+    an.data.add(None)
 
 
 # FileMetadata

--- a/tests/jams_test.py
+++ b/tests/jams_test.py
@@ -189,6 +189,7 @@ def test_annotation():
             eq_(dict(sandbox), dict(ann.sandbox))
 
         if data is not None:
+            eq_(len(ann), len(data))
             eq_(len(ann.data), len(data))
             for obs1, obs2 in zip(ann.data, data):
                 eq_(obs1._asdict(), obs2)

--- a/tests/jams_test.py
+++ b/tests/jams_test.py
@@ -621,6 +621,10 @@ def test_load_fail():
         yield raises(jams.ParameterError)(__test), '{:s}.{:s}'.format(badfile, ext), 'auto'
         yield raises(jams.ParameterError)(__test), '{:s}.{:s}'.format(badfile, ext), ext
         yield raises(jams.ParameterError)(__test), '{:s}.jams'.format(badfile), ext
+
+    # one last test, trying to load form a non-file-like object
+    yield raises(jams.ParameterError)(__test), None, 'auto'
+
     os.rmdir(tdir)
 
 
@@ -1145,3 +1149,24 @@ def test_annotation_data_frame():
         eq_(row.duration, data['duration'][i])
         eq_(row.value, data['value'][i])
         eq_(row.confidence, data['confidence'][i])
+
+
+def test_deprecated():
+
+    @jams.core.deprecated('old version', 'new version')
+    def _foo():
+        pass
+
+    warnings.resetwarnings()
+    warnings.simplefilter('always')
+    with warnings.catch_warnings(record=True) as out:
+        _foo()
+
+        # And that the warning triggered
+        assert len(out) > 0
+
+        # And that the category is correct
+        assert out[0].category is DeprecationWarning
+
+        # And that it says the right thing (roughly)
+        assert 'deprecated' in str(out[0].message).lower()

--- a/tests/jams_test.py
+++ b/tests/jams_test.py
@@ -189,8 +189,8 @@ def test_annotation():
             eq_(dict(sandbox), dict(ann.sandbox))
 
         if data is not None:
-            eq_(len(ann.data.obs), len(data))
-            for obs1, obs2 in zip(ann.data.obs, data):
+            eq_(len(ann.data), len(data))
+            for obs1, obs2 in zip(ann.data, data):
                 eq_(obs1._asdict(), obs2)
 
     real_sandbox = jams.Sandbox(description='none')
@@ -220,7 +220,7 @@ def test_annotation_append():
 
     ann.append(**update)
 
-    eq_(ann.data.obs[-1]._asdict(), update)
+    eq_(ann.data[-1]._asdict(), update)
 
 
 def test_annotation_eq():
@@ -1075,7 +1075,7 @@ def test_annotation_data_frame():
                 confidence=[0.9, 0.9, 0.9])
     ann = jams.Annotation(namespace, data=data, time=5.0, duration=10.0)
 
-    df = ann.data.to_dataframe()
+    df = ann.to_dataframe()
 
     eq_(list(df.columns), ['time', 'duration', 'value', 'confidence'])
 

--- a/tests/jams_test.py
+++ b/tests/jams_test.py
@@ -1065,3 +1065,22 @@ def test_jams_slice():
     del slice_metadata['duration']
     assert slice_metadata == orig_metadata
     assert jam_slice.file_metadata.duration == 2
+
+
+def test_annotation_data_frame():
+    namespace = 'tag_open'
+    data = dict(time=[5.0, 5.0, 10.0],
+                duration=[2.0, 4.0, 4.0],
+                value=['one', 'two', 'three'],
+                confidence=[0.9, 0.9, 0.9])
+    ann = jams.Annotation(namespace, data=data, time=5.0, duration=10.0)
+
+    df = ann.data.to_dataframe()
+
+    eq_(list(df.columns), ['time', 'duration', 'value', 'confidence'])
+
+    for i, row in df.iterrows():
+        eq_(row.time, data['time'][i])
+        eq_(row.duration, data['duration'][i])
+        eq_(row.value, data['value'][i])
+        eq_(row.confidence, data['confidence'][i])

--- a/tests/jams_test.py
+++ b/tests/jams_test.py
@@ -549,6 +549,7 @@ def test_jams_save():
     for ext in ['jams', 'jamz']:
         yield __test, ext
 
+
 def test_jams_add():
 
     def __test():

--- a/tests/jams_test.py
+++ b/tests/jams_test.py
@@ -54,6 +54,9 @@ def test_jobject_serialize():
 
     J = jams.JObject(**data)
 
+    # Stick a dummy _value in for testing
+    J._dummy = True
+
     json_jobject = J.dumps(indent=2)
 
     # De-serialize into dicts

--- a/tests/jams_test.py
+++ b/tests/jams_test.py
@@ -246,8 +246,8 @@ def test_annotation_eq():
 
     assert not (ann1 == ann2)
 
-# FileMetadata
 
+# FileMetadata
 def test_filemetadata():
 
     meta = dict(title='Test track',
@@ -260,8 +260,8 @@ def test_filemetadata():
     for k in meta:
         eq_(meta[k], dict_fm[k])
 
-# AnnotationArray
 
+# AnnotationArray
 def test_annotation_array():
 
     arr = jams.AnnotationArray()
@@ -320,6 +320,7 @@ def test_annotation_array_index_simple():
         a1, a2 = anns[i], jam.annotations[i]
         eq_(a1, a2)
 
+
 def test_annotation_array_slice_simple():
 
     jam = jams.JAMS()
@@ -332,6 +333,7 @@ def test_annotation_array_slice_simple():
     res = jam.annotations[:3]
     eq_(len(res), 3)
     assert anns[0] in res
+
 
 def test_annotation_array_index_fancy():
 
@@ -358,6 +360,7 @@ def test_annotation_array_composite():
     eq_(len(jam.annotations['beat', 3:]), 7)
 
     eq_(len(jam.annotations['beat', 2::2]), 4)
+
 
 @raises(IndexError)
 def test_annotation_array_index_error():

--- a/tests/namespace_tests.py
+++ b/tests/namespace_tests.py
@@ -29,10 +29,10 @@ def test_ns_time_invalid():
     def __test(data):
         ann = Annotation(namespace='onset')
 
-        # Bypass the safety checks in add_observation
-        ann.data.obs.insert(0, Observation(time=data['time'],
-                                           duration=data['duration'],
-                                           value=None, confidence=None))
+        # Bypass the safety checks in append
+        ann.data.add(Observation(time=data['time'],
+                                 duration=data['duration'],
+                                 value=None, confidence=None))
 
         ann.validate()
 

--- a/tests/namespace_tests.py
+++ b/tests/namespace_tests.py
@@ -8,8 +8,7 @@ import numpy as np
 from nose.tools import raises
 from jams import SchemaError
 
-from jams import Annotation
-import pandas as pd
+from jams import Annotation, Observation
 
 from util_test import srand
 
@@ -30,12 +29,10 @@ def test_ns_time_invalid():
     def __test(data):
         ann = Annotation(namespace='onset')
 
-        # Bypass the safety chceks in add_observation
-        ann.data.loc[0] = {'time': pd.to_timedelta(data['time'], unit='s'),
-                           'duration': pd.to_timedelta(data['duration'],
-                                                       unit='s'),
-                           'value': None,
-                           'confdence': None}
+        # Bypass the safety checks in add_observation
+        ann.data.obs.insert(0, Observation(time=data['time'],
+                                           duration=data['duration'],
+                                           value=None, confidence=None))
 
         ann.validate()
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -181,7 +181,7 @@ def test_segment_open():
     eq_(ann2.namespace, 'segment_open')
 
     # Check all else is equal
-    pdt.assert_frame_equal(ann.data, ann2.data)
+    eq_(ann.data, ann2.data)
 
 
 def test_tag_open():
@@ -197,7 +197,7 @@ def test_tag_open():
     eq_(ann2.namespace, 'tag_open')
 
     # Check all else is equal
-    pdt.assert_frame_equal(ann.data, ann2.data)
+    eq_(ann.data, ann2.data)
 
 
 def test_chord():
@@ -213,7 +213,7 @@ def test_chord():
     eq_(ann2.namespace, 'chord', ann2)
 
     # Check all else is equal
-    pdt.assert_frame_equal(ann.data, ann2.data)
+    assert ann.data == ann2.data
 
 
 def test_beat_position():
@@ -236,12 +236,12 @@ def test_beat_position():
     # Check the namespace
     eq_(ann2.namespace, 'beat')
 
-    npt.assert_allclose(ann2.data.value.values, np.arange(1, 5))
-
     # Check all else is equal
-    pdt.assert_series_equal(ann.data.time, ann2.data.time)
-    pdt.assert_series_equal(ann.data.duration, ann2.data.duration)
-    pdt.assert_series_equal(ann.data.confidence, ann2.data.confidence)
+    eq_(len(ann), len(ann2))
+    for obs1, obs2 in zip(ann.data, ann2.data):
+        eq_(obs1.time, obs2.time)
+        eq_(obs1.duration, obs2.duration)
+        eq_(obs1.confidence, obs2.confidence)
 
 
 def test_can_convert_equal():

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -58,16 +58,16 @@ def test_pitch_hz_to_contour():
     eq_(ann2.namespace, 'pitch_contour')
 
     # Check index values
-    eq_(ann2.data.obs[0].value['index'], 0)
-    eq_(ann2.data.obs[-1].value['index'], 0)
+    eq_(ann2.data[0].value['index'], 0)
+    eq_(ann2.data[-1].value['index'], 0)
 
     # Check frequency
-    eq_(np.abs(ann2.data.obs[0].value['frequency']), np.abs(values[0]))
-    eq_(np.abs(ann2.data.obs[-1].value['frequency']), np.abs(values[-1]))
+    eq_(np.abs(ann2.data[0].value['frequency']), np.abs(values[0]))
+    eq_(np.abs(ann2.data[-1].value['frequency']), np.abs(values[-1]))
 
     # Check voicings
-    assert not ann2.data.obs[0].value['voiced']
-    assert ann2.data.obs[-1].value['voiced']
+    assert not ann2.data[0].value['voiced']
+    assert ann2.data[-1].value['voiced']
 
 
 def test_pitch_midi_to_contour():
@@ -86,11 +86,11 @@ def test_pitch_midi_to_contour():
     eq_(ann2.namespace, 'pitch_contour')
 
     # Check index values
-    eq_(ann2.data.obs[0].value['index'], 0)
-    eq_(ann2.data.obs[-1].value['index'], 0)
+    eq_(ann2.data[0].value['index'], 0)
+    eq_(ann2.data[-1].value['index'], 0)
 
     # Check voicings
-    assert ann2.data.obs[-1].value['voiced']
+    assert ann2.data[-1].value['voiced']
 
 
 def test_pitch_midi_to_hz():
@@ -104,7 +104,7 @@ def test_pitch_midi_to_hz():
     # Check the namespace
     eq_(ann2.namespace, 'pitch_hz')
     # midi 69 = 440.0 Hz
-    eq_(ann2.data.obs[0].value, 440.0)
+    eq_(ann2.data[0].value, 440.0)
 
     # Check all else is equal
     eq_(len(ann.data), len(ann2.data))
@@ -126,7 +126,7 @@ def test_pitch_hz_to_midi():
     # Check the namespace
     eq_(ann2.namespace, 'pitch_midi')
     # midi 69 = 440.0 Hz
-    eq_(ann2.data.obs[0].value, 69)
+    eq_(ann2.data[0].value, 69)
 
     # Check all else is equal
     eq_(len(ann.data), len(ann2.data))
@@ -148,7 +148,7 @@ def test_note_midi_to_hz():
     # Check the namespace
     eq_(ann2.namespace, 'note_hz')
     # midi 69 = 440.0 Hz
-    eq_(ann2.data.obs[0].value, 440.0)
+    eq_(ann2.data[0].value, 440.0)
 
     # Check all else is equal
     eq_(len(ann.data), len(ann2.data))
@@ -170,7 +170,7 @@ def test_note_hz_to_midi():
     # Check the namespace
     eq_(ann2.namespace, 'note_midi')
     # midi 69 = 440.0 Hz
-    eq_(ann2.data.obs[0].value, 69)
+    eq_(ann2.data[0].value, 69)
 
     # Check all else is equal
     eq_(len(ann.data), len(ann2.data))

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -3,8 +3,6 @@
 '''namespace conversion tests'''
 
 import numpy as np
-import numpy.testing as npt
-import pandas.util.testing as pdt
 
 from nose.tools import raises, eq_
 import jams

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -41,6 +41,7 @@ def test_noop():
     for ns in jams.schema.__NAMESPACE__:
         yield __test, ns
 
+
 def test_pitch_hz_to_contour():
 
     ann = jams.Annotation(namespace='pitch_hz')
@@ -59,16 +60,17 @@ def test_pitch_hz_to_contour():
     eq_(ann2.namespace, 'pitch_contour')
 
     # Check index values
-    eq_(ann2.data.value.iloc[0]['index'], 0)
-    eq_(ann2.data.value.iloc[-1]['index'], 0)
+    eq_(ann2.data.obs[0].value['index'], 0)
+    eq_(ann2.data.obs[-1].value['index'], 0)
 
     # Check frequency
-    eq_(np.abs(ann2.data.value.iloc[0]['frequency']), np.abs(values[0]))
-    eq_(np.abs(ann2.data.value.iloc[-1]['frequency']), np.abs(values[-1]))
+    eq_(np.abs(ann2.data.obs[0].value['frequency']), np.abs(values[0]))
+    eq_(np.abs(ann2.data.obs[-1].value['frequency']), np.abs(values[-1]))
 
     # Check voicings
-    assert not ann2.data.value.iloc[0]['voiced']
-    assert ann2.data.value.iloc[-1]['voiced']
+    assert not ann2.data.obs[0].value['voiced']
+    assert ann2.data.obs[-1].value['voiced']
+
 
 def test_pitch_midi_to_contour():
 
@@ -86,11 +88,11 @@ def test_pitch_midi_to_contour():
     eq_(ann2.namespace, 'pitch_contour')
 
     # Check index values
-    eq_(ann2.data.value.iloc[0]['index'], 0)
-    eq_(ann2.data.value.iloc[-1]['index'], 0)
+    eq_(ann2.data.obs[0].value['index'], 0)
+    eq_(ann2.data.obs[-1].value['index'], 0)
 
     # Check voicings
-    assert ann2.data.value.iloc[-1]['voiced']
+    assert ann2.data.obs[-1].value['voiced']
 
 
 def test_pitch_midi_to_hz():
@@ -104,12 +106,15 @@ def test_pitch_midi_to_hz():
     # Check the namespace
     eq_(ann2.namespace, 'pitch_hz')
     # midi 69 = 440.0 Hz
-    eq_(ann2.data.value.loc[0], 440.0)
+    eq_(ann2.data.obs[0].value, 440.0)
 
     # Check all else is equal
-    pdt.assert_series_equal(ann.data.time, ann2.data.time)
-    pdt.assert_series_equal(ann.data.duration, ann2.data.duration)
-    pdt.assert_series_equal(ann.data.confidence, ann2.data.confidence)
+    eq_(len(ann.data), len(ann2.data))
+
+    for obs1, obs2 in zip(ann.data, ann2.data):
+        eq_(obs1.time, obs2.time)
+        eq_(obs1.duration, obs2.duration)
+        eq_(obs1.confidence, obs2.confidence)
 
 
 def test_pitch_hz_to_midi():
@@ -123,12 +128,15 @@ def test_pitch_hz_to_midi():
     # Check the namespace
     eq_(ann2.namespace, 'pitch_midi')
     # midi 69 = 440.0 Hz
-    eq_(ann2.data.value.loc[0], 69)
+    eq_(ann2.data.obs[0].value, 69)
 
     # Check all else is equal
-    pdt.assert_series_equal(ann.data.time, ann2.data.time)
-    pdt.assert_series_equal(ann.data.duration, ann2.data.duration)
-    pdt.assert_series_equal(ann.data.confidence, ann2.data.confidence)
+    eq_(len(ann.data), len(ann2.data))
+
+    for obs1, obs2 in zip(ann.data, ann2.data):
+        eq_(obs1.time, obs2.time)
+        eq_(obs1.duration, obs2.duration)
+        eq_(obs1.confidence, obs2.confidence)
 
 
 def test_note_midi_to_hz():
@@ -142,12 +150,15 @@ def test_note_midi_to_hz():
     # Check the namespace
     eq_(ann2.namespace, 'note_hz')
     # midi 69 = 440.0 Hz
-    eq_(ann2.data.value.loc[0], 440.0)
+    eq_(ann2.data.obs[0].value, 440.0)
 
     # Check all else is equal
-    pdt.assert_series_equal(ann.data.time, ann2.data.time)
-    pdt.assert_series_equal(ann.data.duration, ann2.data.duration)
-    pdt.assert_series_equal(ann.data.confidence, ann2.data.confidence)
+    eq_(len(ann.data), len(ann2.data))
+
+    for obs1, obs2 in zip(ann.data, ann2.data):
+        eq_(obs1.time, obs2.time)
+        eq_(obs1.duration, obs2.duration)
+        eq_(obs1.confidence, obs2.confidence)
 
 
 def test_note_hz_to_midi():
@@ -161,12 +172,16 @@ def test_note_hz_to_midi():
     # Check the namespace
     eq_(ann2.namespace, 'note_midi')
     # midi 69 = 440.0 Hz
-    eq_(ann2.data.value.loc[0], 69)
+    eq_(ann2.data.obs[0].value, 69)
 
     # Check all else is equal
-    pdt.assert_series_equal(ann.data.time, ann2.data.time)
-    pdt.assert_series_equal(ann.data.duration, ann2.data.duration)
-    pdt.assert_series_equal(ann.data.confidence, ann2.data.confidence)
+    eq_(len(ann.data), len(ann2.data))
+
+    for obs1, obs2 in zip(ann.data, ann2.data):
+        eq_(obs1.time, obs2.time)
+        eq_(obs1.duration, obs2.duration)
+        eq_(obs1.confidence, obs2.confidence)
+
 
 def test_segment_open():
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -4,10 +4,9 @@
 
 import tempfile
 import os
-from nose.tools import eq_, raises
+from nose.tools import eq_
 import numpy as np
 
-import jams
 from jams import core, util
 
 
@@ -45,10 +44,10 @@ def test_import_lab():
         _, ann = util.import_lab(ns, six.StringIO(lab),
                                  infer_duration=infer_duration)
 
-        eq_(len(ints), len(ann.data))
-        eq_(len(y), len(ann.data))
+        eq_(len(ints), len(ann))
+        eq_(len(y), len(ann))
 
-        for yi, ival, obs in zip(y, ints, ann.data):
+        for yi, ival, obs in zip(y, ints, ann):
             eq_(obs.time, ival[0])
             eq_(obs.duration, ival[1] - ival[0])
             eq_(obs.value, yi)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -44,8 +44,8 @@ def test_import_lab():
         _, ann = util.import_lab(ns, six.StringIO(lab),
                                  infer_duration=infer_duration)
 
-        eq_(len(ints), len(ann))
-        eq_(len(y), len(ann))
+        eq_(len(ints), len(ann.data))
+        eq_(len(y), len(ann.data))
 
         for yi, ival, obs in zip(y, ints, ann):
             eq_(obs.time, ival[0])

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -45,12 +45,13 @@ def test_import_lab():
         _, ann = util.import_lab(ns, six.StringIO(lab),
                                  infer_duration=infer_duration)
 
-        assert np.allclose(core.timedelta_to_float(ann.data['time'].values),
-                           ints[:, 0])
-        assert np.allclose(core.timedelta_to_float(ann.data['duration'].values),
-                           ints[:, 1] - ints[:, 0])
-        for y1, y2 in zip(list(ann.data['value'].values), y):
-            eq_(y1, y2)
+        eq_(len(ints), len(ann.data))
+        eq_(len(y), len(ann.data))
+
+        for yi, ival, obs in zip(y, ints, ann.data):
+            eq_(obs.time, ival[0])
+            eq_(obs.duration, ival[1] - ival[0])
+            eq_(obs.value, yi)
 
     for ns, lab, ints, y, inf in zip(namespace, labs, intervals, labels, durations):
         yield __test, ns, lab, ints, y, inf

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -56,17 +56,6 @@ def test_import_lab():
         yield __test, ns, lab, ints, y, inf
 
 
-def test_timedelta_to_float():
-
-    # 2.5 seconds
-    t = 2.5
-    x = np.timedelta64(int(t * 1e9))
-    tn = core.timedelta_to_float(x)
-
-    # convert back
-    assert np.allclose(t, tn)
-
-
 def test_query_pop():
 
     def __test(query, prefix, sep, target):


### PR DESCRIPTION
This is  work in progress, but implements an alternate backend for annotation data.

TODO:

- [x] trim
- [x] slice
- [x] deep serialization (eg for vector format)
- [x] pretty printing
- [x] purge all pandas references
- [x] settle on final object hierarchy / naming conventions
- [x] update converter scripts and documentation / examples