### PR TITLE
import_lab only constructs an Annotation, not jams object (fixed #124)

### DIFF
--- a/docs/examples/example_chord_import.py
+++ b/docs/examples/example_chord_import.py
@@ -8,15 +8,18 @@ def import_chord_jams(infile, outfile):
 
     # import_lab returns a new jams object,
     # and a handle to the newly created annotation
-    jam, chords = jams.util.import_lab('chord', infile)
+    chords = jams.util.import_lab('chord', infile)
 
     # Infer the track duration from the end of the last annotation
     duration = max([obs.time + obs.duration for obs in chords])
 
-    jam.file_metadata.duration = duration
-
     chords.time = 0
     chords.duration = duration
+
+    # Create a jams object
+    jam = jams.JAMS()
+    jam.file_metadata.duration = duration
+    jam.annotations.append(chords)
 
     # save to disk
     jam.save(outfile)

--- a/jams/util.py
+++ b/jams/util.py
@@ -21,8 +21,8 @@ import pandas as pd
 from . import core
 
 
-def import_lab(namespace, filename, jam=None, infer_duration=True, **parse_options):
-    r'''Load a .lab file into a JAMS object.
+def import_lab(namespace, filename, infer_duration=True, **parse_options):
+    r'''Load a .lab file as an Annotation object.
 
     .lab files are assumed to have the following format:
 
@@ -47,10 +47,6 @@ def import_lab(namespace, filename, jam=None, infer_duration=True, **parse_optio
     filename : str
         Path to the .lab file
 
-    jam : jams.JAMS (optional)
-        An optional pre-existing JAMS object to append into.
-        If `None`, a new, blank JAMS object is created.
-
     infer_duration : bool
         If `True`, interval durations are inferred from `(start, end)` columns,
         or difference between successive times.
@@ -59,19 +55,16 @@ def import_lab(namespace, filename, jam=None, infer_duration=True, **parse_optio
         `(start, duration)` columns.  If only one time column is given, then
         durations are set to 0.
 
-        For instantaneous event annotations (e.g., beats or onsets), this should
-        be set to `False`.
+        For instantaneous event annotations (e.g., beats or onsets), this
+        should be set to `False`.
 
     parse_options : additional keyword arguments
         Passed to ``pandas.DataFrame.read_csv``
 
     Returns
     -------
-    jam : JAMS
-        The modified or constructed JAMS object
-
     annotation : Annotation
-        A handle to the newly constructed annotation object
+        The newly constructed annotation object
 
     See Also
     --------
@@ -80,9 +73,6 @@ def import_lab(namespace, filename, jam=None, infer_duration=True, **parse_optio
 
     # Create a new annotation object
     annotation = core.Annotation(namespace)
-
-    if jam is None:
-        jam = core.JAMS()
 
     parse_options.setdefault('sep', r'\s+')
     parse_options.setdefault('engine', 'python')
@@ -120,9 +110,7 @@ def import_lab(namespace, filename, jam=None, infer_duration=True, **parse_optio
                           confidence=1.0,
                           value=value)
 
-    jam.annotations.append(annotation)
-
-    return jam, annotation
+    return annotation
 
 
 def expand_filepaths(base_dir, rel_paths):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -41,8 +41,8 @@ def test_import_lab():
     durations = [True, False, True, False]
 
     def __test(ns, lab, ints, y, infer_duration):
-        _, ann = util.import_lab(ns, six.StringIO(lab),
-                                 infer_duration=infer_duration)
+        ann = util.import_lab(ns, six.StringIO(lab),
+                              infer_duration=infer_duration)
 
         eq_(len(ints), len(ann.data))
         eq_(len(y), len(ann.data))


### PR DESCRIPTION
This PR modifies `import_lab` to only return the annotation object, and not create or populate a jams object.