### PR TITLE
improved repr and repr_html

### DIFF
--- a/jams/core.py
+++ b/jams/core.py
@@ -322,13 +322,8 @@ class JObject(object):
     def _display_properties(self):
         '''Returns a list of tuples (key, display_name)
         for properties of this object'''
-        schema = self.__schema__
-        if not schema or 'properties' not in schema:
-            props = self.__dict__.keys()
-        else:
-            props = schema['properties'].keys()
 
-        return sorted([(k, k) for k in props])
+        return sorted([(k, k) for k in self.__dict__])
 
     def _repr_html_(self):
 

--- a/jams/core.py
+++ b/jams/core.py
@@ -382,7 +382,7 @@ class JObject(object):
             else:
                 out += r'''<div class="panel-heading">
                                 {}&nbsp;
-                                <span class="pull-right">{}</span>
+                                <span class="pull-right"><em>{}</em></span>
                            </div>'''.format(dprop, content)
             out += '</div>'
         out += '</div>'

--- a/jams/core.py
+++ b/jams/core.py
@@ -1031,7 +1031,7 @@ class Annotation(JObject):
     def __iter__(self):
         return iter(self.data)
 
-    def to_html(self):
+    def to_html(self, max_rows=None):
         '''Render this annotation list in HTML
 
         Returns
@@ -1039,7 +1039,11 @@ class Annotation(JObject):
         rendered : str
             An HTML table containing this annotation's data.
         '''
+        n = len(self.data)
         out = r'''<table border="1" class="dataframe">
+                    <caption>
+                        <em>{:s}</em> annotation: {:d} observation(s)
+                    </caption>
                     <thead>
                         <tr style="text-align: right;">
                             <th></th>
@@ -1048,13 +1052,35 @@ class Annotation(JObject):
                             <th>value</th>
                             <th>confidence</th>
                         </tr>
-                    </thead>'''
+                    </thead>'''.format(self.namespace, n)
+
         out += r'''<tbody>'''
-        for i, obs in enumerate(self.data):
+
+        if max_rows is None or n <= max_rows:
+            out += self._fmt_rows(0, n)
+        else:
+            out += self._fmt_rows(0, max_rows//2)
+            out += r'''<tr>
+                            <th>...</th>
+                            <td>...</td>
+                            <td>...</td>
+                            <td>...</td>
+                            <td>...</td>
+                        </tr>'''
+            out += self._fmt_rows(n-max_rows//2, n)
+
+        out += r'''</tbody>'''
+
+        out += r'''</table>'''
+        return out
+
+    def _fmt_rows(self, start, end):
+        out = ''
+        for i, obs in enumerate(self.data[start:end], start):
             out += r'''<tr>
                             <th>{:d}</th>
-                            <td>{:0.6f}</td>
-                            <td>{:0.6f}</td>
+                            <td>{:0.3f}</td>
+                            <td>{:0.3f}</td>
                             <td>{:}</td>
                             <td>{:}</td>
                         </tr>'''.format(i,
@@ -1062,12 +1088,12 @@ class Annotation(JObject):
                                         obs.duration,
                                         obs.value,
                                         obs.confidence)
-        out += r'''</tbody></table>'''
+
         return out
 
-    def _repr_html_(self):
+    def _repr_html_(self, max_rows=25):
         '''Render annotation as HTML.  See also: `to_html()`'''
-        return self.to_html()
+        return self.to_html(max_rows=max_rows)
 
     @property
     def __json__(self):

--- a/jams/schemata/validate.py
+++ b/jams/schemata/validate.py
@@ -43,5 +43,6 @@ def validate(schema_file=None, jams_files=None):
 
             print exc
 
+
 if __name__ == '__main__':
     validate(**process_arguments(sys.argv[1:]))

--- a/tests/test_jams.py
+++ b/tests/test_jams.py
@@ -102,7 +102,8 @@ def test_jobject_nonzero(data, value):
 
 
 def test_jobject_repr():
-    repr(jams.JObject(foo=1, bar=2))
+    assert (repr(jams.JObject(foo=1, bar=2)) ==
+            '<JObject(bar=2,\n         foo=1)>')
 
 
 def test_jobject_repr_html():

--- a/tests/test_jams.py
+++ b/tests/test_jams.py
@@ -101,8 +101,21 @@ def test_jobject_nonzero(data, value):
     assert J.__nonzero__() == value
 
 
-# Sandbox
+def test_jobject_repr():
+    repr(jams.JObject(foo=1, bar=2))
 
+
+def test_jobject_repr_html():
+    # Test once with empty
+    J2 = jams.JObject()
+    J2._repr_html_()
+
+    # And once with some nested values
+    J = jams.JObject(foo=1, bar=dict(baz=3), qux=[1], quux=None)
+    J._repr_html_()
+
+
+# Sandbox
 def test_sandbox():
 
     data = dict(key1='value 1', key2='value 2')
@@ -517,6 +530,18 @@ def test_jobject_bad_field():
     jam = jams.JAMS()
 
     jam.out_of_schema = None
+
+
+def test_jams_repr(input_jam):
+    repr(input_jam)
+
+
+def test_jams_repr_html(input_jam):
+    input_jam._repr_html_()
+
+
+def test_jams_str(input_jam):
+    str(input_jam)
 
 
 # Load


### PR DESCRIPTION
Tagging @ejhumphrey @justinsalamon @rabitt @urinieto 

This PR is looking at improvements to our repr strings, implementing #93.  Once that's hammered out, i'll start looking at HTML formatting for the notebook.

So far, here's what we've got:

```python
>>> J
<JAMS(annotations=[4 annotations],
      file_metadata=<FileMetadata(...)>,
      sandbox=<Sandbox(...)>)>

>>> J.file_metadata
<FileMetadata(artist='The Beatles',
              duration=119.333,
              identifiers=<Sandbox(...)>,
              jams_version='0.2.0',
              release='',
              title='11_-_Do_You_Want_To_Know_A_Secret')>

>>> J.annotations
[4 annotations]

>>> J.annotations[0]
<Annotation(annotation_metadata=<AnnotationMetadata(...)>,
            data=<114 observations>,
            duration=None,
            namespace='chord',
            sandbox=<Sandbox(...)>,
            time=0)>
```

I've added a couple of helper methods and an external `summary` function that knows how to make condensed summaries of JObjects.

Note: the old version, for comparison's sake, would look like this:
```python
>>> J
<JAMS: sandbox, file_metadata, annotations>

>>> J.file_metadata
<FileMetadata: title, identifiers, artist, jams_version, duration, release>

>>> J.annotations
[<Annotation: namespace, sandbox, data, time, duration, annotation_metadata>,
 <Annotation: namespace, sandbox, data, time, duration, annotation_metadata>,
 <Annotation: namespace, sandbox, data, time, duration, annotation_metadata>,
 <Annotation: namespace, sandbox, data, time, duration, annotation_metadata>]

>>> J.annotations[0]
<Annotation: namespace, sandbox, data, time, duration, annotation_metadata>
```

What do folks think?  Is there anything that seems too complex, or other information that should be surfaced in the repr?  This still doesn't quite satisfy the intended semantics of `repr` as returning a string which reproduces the same object when entered into the interpreter, but it's at least more informative than the old version.