### PR TITLE
Numpy JSON serialization

### DIFF
--- a/jams/core.py
+++ b/jams/core.py
@@ -273,7 +273,7 @@ class JObject(object):
             if hasattr(item, '__json__'):
                 filtered_dict[k] = item.__json__
             else:
-                filtered_dict[k] = item
+                filtered_dict[k] = serialize_obj(item)
 
         return filtered_dict
 
@@ -693,8 +693,8 @@ class Annotation(JObject):
         >>> ann.append(time=3, duration=2, value='E#')
         '''
 
-        self.data.add(Observation(time=time,
-                                  duration=duration,
+        self.data.add(Observation(time=float(time),
+                                  duration=float(duration),
                                   value=value,
                                   confidence=confidence))
 
@@ -1992,7 +1992,13 @@ def serialize_obj(obj):
 
     '''
 
-    if isinstance(obj, np.ndarray):
+    if isinstance(obj, np.integer):
+        return int(obj)
+
+    elif isinstance(obj, np.floating):
+        return float(obj)
+
+    elif isinstance(obj, np.ndarray):
         return obj.tolist()
 
     elif isinstance(obj, list):

--- a/tests/test_jams.py
+++ b/tests/test_jams.py
@@ -1117,3 +1117,9 @@ def test_deprecated():
 
         # And that it says the right thing (roughly)
         assert 'deprecated' in str(out[0].message).lower()
+
+
+def test_numpy_serialize():
+
+    jobj = jams.JObject(key=np.float32(1.0))
+    jobj.__json__

--- a/tests/test_jams.py
+++ b/tests/test_jams.py
@@ -1123,3 +1123,11 @@ def test_numpy_serialize():
     # Test to trigger issue #159 - serializing numpy dtypes
     jobj = jams.JObject(key=np.float32(1.0))
     jobj.dumps()
+
+
+def test_annotation_serialize():
+    # Secondary test to trigger #159 on observation data
+    ann = jams.Annotation(namespace='tag_open', duration=1.0)
+    ann.append(time=np.float32(0), duration=np.float32(1),
+               value=np.float32(5), confidence=np.float32(0.5))
+    ann.dumps()

--- a/tests/test_jams.py
+++ b/tests/test_jams.py
@@ -1120,6 +1120,6 @@ def test_deprecated():
 
 
 def test_numpy_serialize():
-
+    # Test to trigger issue #159 - serializing numpy dtypes
     jobj = jams.JObject(key=np.float32(1.0))
-    jobj.__json__
+    jobj.dumps()


### PR DESCRIPTION
This PR fixes #159 by doing explicit type coercion on numpy scalars when converting to JSON.

It's a bit of a stop-gap solution for now.  I think we should at some point re-structure how `serialize_obj` is implemented and used, so that it applies transparently throughout all `__json__` calls.  That's probably out of scope for this fix though, so this PR should be ready to go.