### PR TITLE
display viz mappings: equal parts RFC and PR

### DIFF
--- a/jams/display.py
+++ b/jams/display.py
@@ -132,14 +132,15 @@ def piano_roll(annotation, **kwargs):
 
 VIZ_MAPPING = OrderedDict()
 
-VIZ_MAPPING['segment_open'] = intervals
+VIZ_MAPPING['beat'] = event
+VIZ_MAPPING['beat_position'] = beat_position
 VIZ_MAPPING['chord'] = intervals
 VIZ_MAPPING['multi_segment'] = hierarchy
-VIZ_MAPPING['pitch_contour'] = pitch_contour
-VIZ_MAPPING['beat_position'] = beat_position
-VIZ_MAPPING['beat'] = event
-VIZ_MAPPING['onset'] = event
 VIZ_MAPPING['note_midi'] = piano_roll
+VIZ_MAPPING['onset'] = event
+VIZ_MAPPING['pitch_contour'] = pitch_contour
+VIZ_MAPPING['segment_open'] = intervals
+VIZ_MAPPING['tag_open'] = intervals
 
 
 def display(annotation, meta=True, **kwargs):


### PR DESCRIPTION
The jams.display submodule rocks but I've had to override the `VIZ_MAPPING` symbol table to use it with different namespaces, e.g. `tag_open`. I've taken the liberty of adding that one here, and alphabetizing the symbol table so we can add to it with some kind of convention going forward.

but!

this might be indicative of something we want to fix in general, and I'm curious to kick it around (here, I guess?). Should a namespace JSON file *also* specify how it should be visualized? seems like adding this info in two places is a design smell.

also: happy to move this to an issue first.