### PR TITLE
Update documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ jams
 
 A JSON Annotated Music Specification for Reproducible MIR Research.
 
-Please, refer to [documentation](http://pythonhosted.org/jams/) for a comprehensive
+Please, refer to [documentation](http://jams.readthedocs.io/en/stable/) for a comprehensive
 description of JAMS.
 
 What
@@ -45,7 +45,7 @@ This library is offered as a proof-of-concept, demonstrating the promise of a
 JSON-based schema to meet the needs of the MIR community. To install, clone the
 repository into a working directory and proceed thusly.
 
-The full documentation can be found [here](http://pythonhosted.org/jams/).
+The full documentation can be found [here](http://jams.readthedocs.io/en/stable/).
 
 Who
 ----


### PR DESCRIPTION
Change: http://pythonhosted.org/jams/ to http://jams.readthedocs.io/en/stable/