### PR TITLE
added display linkage for tag namespaces

### DIFF
--- a/jams/display.py
+++ b/jams/display.py
@@ -140,6 +140,7 @@ VIZ_MAPPING['beat_position'] = beat_position
 VIZ_MAPPING['beat'] = event
 VIZ_MAPPING['onset'] = event
 VIZ_MAPPING['note_midi'] = piano_roll
+VIZ_MAPPING['tag_open'] = intervals
 
 
 def display(annotation, meta=True, **kwargs):

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -18,7 +18,7 @@ from jams import NamespaceError
 @pytest.mark.parametrize('namespace',
                          ['segment_open', 'chord', 'multi_segment',
                           'pitch_contour', 'beat_position', 'beat',
-                          'onset', 'note_midi',
+                          'onset', 'note_midi', 'tag_open',
                           pytest.mark.xfail('tempo', raises=NamespaceError)])
 @pytest.mark.parametrize('meta', [False, True])
 def test_display(namespace, meta):


### PR DESCRIPTION
Re-implements #177.  No need for CR on this one.