### PR TITLE
Fixed annotation.slice timing and docstring examples

### DIFF
--- a/jams/core.py
+++ b/jams/core.py
@@ -861,7 +861,7 @@ class Annotation(JObject):
         >>> ann_trim_strict = ann.trim(5, 8, strict=True)
         >>> print(ann_trim_strict.time, ann_trim_strict.duration)
         (5, 3)
-        >>> ann_trim_strict.data
+        >>> ann_trim_strict.to_dataframe()
            time  duration  value confidence
         0     6         2  three       None
         '''
@@ -1000,18 +1000,18 @@ class Annotation(JObject):
         >>> ann.append(time=8, duration=2, value='five')
         >>> ann_slice = ann.slice(5, 8, strict=False)
         >>> print(ann_slice.time, ann_slice.duration)
-        (0, 3)
-        >>> ann_slice.data
+        (5, 3)
+        >>> ann_slice.to_dataframe()
            time  duration  value confidence
-        0     0         1    two       None
-        1     1         2  three       None
-        2     2         1   four       None
+        0   0.0       1.0    two       None
+        1   1.0       2.0  three       None
+        2   2.0       1.0   four       None
         >>> ann_slice_strict = ann.slice(5, 8, strict=True)
         >>> print(ann_slice_strict.time, ann_slice_strict.duration)
-        (0, 3)
-        >>> ann_slice_strict.data
+        (5, 3)
+        >>> ann_slice_strict.to_dataframe()
            time  duration  value confidence
-        0     1         2  three       None
+        0   1.0       2.0  three       None
         '''
         # start by trimming the annotation
         sliced_ann = self.trim(start_time, end_time, strict=strict)

--- a/jams/core.py
+++ b/jams/core.py
@@ -1000,7 +1000,7 @@ class Annotation(JObject):
         >>> ann.append(time=8, duration=2, value='five')
         >>> ann_slice = ann.slice(5, 8, strict=False)
         >>> print(ann_slice.time, ann_slice.duration)
-        (5, 3)
+        (0, 3)
         >>> ann_slice.to_dataframe()
            time  duration  value confidence
         0   0.0       1.0    two       None
@@ -1008,7 +1008,7 @@ class Annotation(JObject):
         2   2.0       1.0   four       None
         >>> ann_slice_strict = ann.slice(5, 8, strict=True)
         >>> print(ann_slice_strict.time, ann_slice_strict.duration)
-        (5, 3)
+        (0, 3)
         >>> ann_slice_strict.to_dataframe()
            time  duration  value confidence
         0   1.0       2.0  three       None
@@ -1043,6 +1043,9 @@ class Annotation(JObject):
             sliced_ann.sandbox.slice.append(
                 {'start_time': start_time, 'end_time': end_time,
                  'slice_start': slice_start, 'slice_end': slice_end})
+
+        # Update the timing for the sliced annotation
+        sliced_ann.time = max(0, ref_time - start_time)
 
         return sliced_ann
 

--- a/tests/test_jams.py
+++ b/tests/test_jams.py
@@ -1026,8 +1026,8 @@ def test_annotation_slice():
                                         'end_time': 10,
                                         'slice_start': 8,
                                         'slice_end': 10}]
-    assert ann_slice.time == 0
-    assert ann_slice.duration == 2
+    assert ann_slice.time == expected_ann.time
+    assert ann_slice.duration == expected_ann.duration
 
     # Slice out range that's partially inside the time range spanned by the
     # annotation (starts BEFORE annotation starts)
@@ -1039,8 +1039,8 @@ def test_annotation_slice():
 
     expected_ann = jams.Annotation(namespace, data=expected_data, time=2.0,
                                    duration=5.0)
-    assert ann_slice.time == 2
-    assert ann_slice.duration == 5
+    assert ann_slice.time == expected_ann.time
+    assert ann_slice.duration == expected_ann.duration
 
     assert ann_slice.data == expected_ann.data
     assert ann_slice.sandbox.slice == [{'start_time': 3,
@@ -1057,13 +1057,13 @@ def test_annotation_slice():
                          confidence=[0.9, 0.9])
 
     expected_ann = jams.Annotation(namespace, data=expected_data, time=0,
-                                   duration=2.0)
+                                   duration=7.0)
 
     assert ann_slice.data == expected_ann.data
     assert ann_slice.sandbox.slice == (
         [{'start_time': 8, 'end_time': 20, 'slice_start': 8, 'slice_end': 15}])
-    assert ann_slice.time == 0
-    assert ann_slice.duration == 7
+    assert ann_slice.time == expected_ann.time
+    assert ann_slice.duration == expected_ann.duration
 
     # Multiple slices
     ann_slice = ann.slice(0, 10).slice(8, 10)
@@ -1079,8 +1079,8 @@ def test_annotation_slice():
     assert ann_slice.sandbox.slice == (
         [{'start_time': 0, 'end_time': 10, 'slice_start': 5, 'slice_end': 10},
          {'start_time': 8, 'end_time': 10, 'slice_start': 8, 'slice_end': 10}])
-    assert ann_slice.time == 0
-    assert ann_slice.duration == 2
+    assert ann_slice.time == expected_ann.time
+    assert ann_slice.duration == expected_ann.duration
 
 
 def test_jams_slice():

--- a/tests/test_jams.py
+++ b/tests/test_jams.py
@@ -1026,6 +1026,8 @@ def test_annotation_slice():
                                         'end_time': 10,
                                         'slice_start': 8,
                                         'slice_end': 10}]
+    assert ann_slice.time == 0
+    assert ann_slice.duration == 2
 
     # Slice out range that's partially inside the time range spanned by the
     # annotation (starts BEFORE annotation starts)
@@ -1037,6 +1039,8 @@ def test_annotation_slice():
 
     expected_ann = jams.Annotation(namespace, data=expected_data, time=2.0,
                                    duration=5.0)
+    assert ann_slice.time == 2
+    assert ann_slice.duration == 5
 
     assert ann_slice.data == expected_ann.data
     assert ann_slice.sandbox.slice == [{'start_time': 3,
@@ -1058,6 +1062,8 @@ def test_annotation_slice():
     assert ann_slice.data == expected_ann.data
     assert ann_slice.sandbox.slice == (
         [{'start_time': 8, 'end_time': 20, 'slice_start': 8, 'slice_end': 15}])
+    assert ann_slice.time == 0
+    assert ann_slice.duration == 7
 
     # Multiple slices
     ann_slice = ann.slice(0, 10).slice(8, 10)
@@ -1073,6 +1079,8 @@ def test_annotation_slice():
     assert ann_slice.sandbox.slice == (
         [{'start_time': 0, 'end_time': 10, 'slice_start': 5, 'slice_end': 10},
          {'start_time': 8, 'end_time': 10, 'slice_start': 8, 'slice_end': 10}])
+    assert ann_slice.time == 0
+    assert ann_slice.duration == 2
 
 
 def test_jams_slice():
@@ -1110,6 +1118,7 @@ def test_jams_slice():
 
     assert jam_slice.file_metadata.duration == 10
     assert jam_slice.sandbox.slice == [{'start_time': 0, 'end_time': 10}]
+
 
     # Multiple trims
     jam_slice = jam.slice(0, 10).slice(8, 10)


### PR DESCRIPTION
I fixed this just by changing the `ann_slice.data` line to `ann_slice.to_dataframe()`.  Fixes #174 

This shouldn't need a CR, but I did notice that the output in the examples was incorrect.  When it prints `ann_slice.time, ann_slice.duration`, it was giving `(0, 3)` in the docstring.  When I run the code, it gives `(5, 3)`.  @justinsalamon which of these should be considered correct?