### PR TITLE
pin jsonschema dependency to 2.6, update jams version

### DIFF
--- a/jams/version.py
+++ b/jams/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '0.3'
-version = '0.3.2'
+version = '0.3.3'

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     extras_require={
         'display': ['matplotlib>=1.5.0'],
-        'tests': ['pytest', 'pytest-cov'],
+        'tests': ['pytest < 4', 'pytest-cov'],
     },
     scripts=['scripts/jams_to_lab.py']
 )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'pandas',
         'sortedcontainers>=2.0.0',
-        'jsonschema',
+        'jsonschema==2.6',
         'numpy>=1.8.0',
         'six',
         'decorator',


### PR DESCRIPTION
This PR is a temporary version pin for the jsonschema dependency to 2.6 until we get things sorted out for 3.0 compatibility.

This increments the jams minor version.