### PR TITLE
Support jsonschema>=3.0

### DIFF
--- a/jams/core.py
+++ b/jams/core.py
@@ -581,7 +581,7 @@ class JObject(object):
         valid = True
 
         try:
-            jsonschema.validate(self.__json__, self.__schema__)
+            schema.VALIDATOR.validate(self.__json__, self.__schema__)
 
         except jsonschema.ValidationError as invalid:
             if strict:
@@ -766,12 +766,12 @@ class Annotation(JObject):
         valid = True
 
         try:
-            jsonschema.validate(self.__json_light__(data=False),
-                                schema.JAMS_SCHEMA)
+            schema.VALIDATOR.validate(self.__json_light__(data=False),
+                                                schema.JAMS_SCHEMA)
 
             # validate each record in the frame
             data_ser = [serialize_obj(obs) for obs in self.data]
-            jsonschema.validate(data_ser, ann_schema)
+            schema.VALIDATOR.validate(data_ser, ann_schema)
 
         except jsonschema.ValidationError as invalid:
             if strict:
@@ -1805,7 +1805,7 @@ class JAMS(JObject):
         '''
         valid = True
         try:
-            jsonschema.validate(self.__json_light__, schema.JAMS_SCHEMA)
+            schema.VALIDATOR.validate(self.__json_light__, schema.JAMS_SCHEMA)
 
             for ann in self.annotations:
                 if isinstance(ann, Annotation):

--- a/jams/schema.py
+++ b/jams/schema.py
@@ -24,10 +24,11 @@ import copy
 from pkg_resources import resource_filename
 
 import numpy as np
+import jsonschema
 
 from .exceptions import NamespaceError, JamsError
 
-__all__ = ['add_namespace', 'namespace', 'is_dense', 'values', 'get_dtypes']
+__all__ = ['add_namespace', 'namespace', 'is_dense', 'values', 'get_dtypes', 'VALIDATOR']
 
 __NAMESPACE__ = dict()
 
@@ -248,3 +249,4 @@ SCHEMA_DIR = 'schemata'
 NS_SCHEMA_DIR = os.path.join(SCHEMA_DIR, 'namespaces')
 
 JAMS_SCHEMA = __load_jams_schema()
+VALIDATOR = jsonschema.Draft4Validator(JAMS_SCHEMA)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'pandas',
         'sortedcontainers>=2.0.0',
-        'jsonschema==2.6',
+        'jsonschema>=3.0.0',
         'numpy>=1.8.0',
         'six',
         'decorator',


### PR DESCRIPTION
This PR updates the jsonschema dependency to support >= 3.0, and fixes #193 .

The fix involves forcing the validator to use draft-04, which is now out of date.  But this stop-gap solution works for now.

We should have a separate issue, tied to #92 , which could involve updating the schema definition itself to draft 7.  There appear to be some good technical reasons for doing so (namely: relative uri references), but we can punt that down the road for now.

