### PR TITLE
Boundary condition on trimming

### DIFF
--- a/docs/jams_structure.rst
+++ b/docs/jams_structure.rst
@@ -29,7 +29,7 @@ Annotation
 
 Each annotation object contains the following properties:
     * ``namespace`` : a string describing the type of this annotation;
-    * ``data`` : a list of observations, each containing:
+    * ``data`` : a list of *observations*, each containing:
         * ``time`` : non-negative number denoting the time of the observation (in seconds)
         * ``duration`` : non-negative number denoting the duration of the observation (in seconds)
         * ``value`` : actual annotation (e.g., chord, segment label)
@@ -41,6 +41,16 @@ Each annotation object contains the following properties:
       annotation.
 
 The permissible contents of the ``value`` and ``confidence`` fields are defined by the ``namespace``.
+
+The interpretation of the ``time`` and ``duration`` observation fields are as follows:
+
+   - if ``duration > 0``, the observation covers the half-open time interval ``[time, time + duration)``.
+   - if ``duration == 0``, the observation covers the closed interval ``[time, time]``, that is, the single time instant.
+
+The first case is the most widely used, and the half-open interval convention eliminates ambiguity of interval membership at the boundaries of adjacent intervals.
+
+The second case is primarily useful for instantaneous measurements (e.g., beat events) or uniformly sampled values of a temporally continuous signal (e.g., fundamental frequency
+curve).
 
 .. note:: The ``time`` and ``duration`` fields of ``annotation`` are considered optional.  If left blank,
           the annotation should be assumed to be valid for the entirety of the track.

--- a/jams/core.py
+++ b/jams/core.py
@@ -916,7 +916,7 @@ class Annotation(JObject):
             obs_start = obs.time
             obs_end = obs_start + obs.duration
 
-            if obs_start < trim_end and obs_end > trim_start:
+            if obs_start < trim_end and obs_end >= trim_start:
 
                 new_start = max(obs_start, trim_start)
                 new_end = min(obs_end, trim_end)

--- a/jams/core.py
+++ b/jams/core.py
@@ -916,7 +916,8 @@ class Annotation(JObject):
             obs_start = obs.time
             obs_end = obs_start + obs.duration
 
-            if obs_start < trim_end and obs_end >= trim_start:
+            # Special-case here handles duration=0 as a closed interval
+            if obs_start < trim_end and (obs_end > trim_start or obs_start == obs_end >= trim_start):
 
                 new_start = max(obs_start, trim_start)
                 new_end = min(obs_end, trim_end)

--- a/tests/test_jams.py
+++ b/tests/test_jams.py
@@ -801,17 +801,17 @@ def test_annotation_trim_partial_overlap_beginning():
     # range: at the beginning
     # strict=False
     namespace = 'tag_open'
-    data = dict(time=[5.0, 5.0, 5.0, 10.0],
-                duration=[0.0, 2.0, 4.0, 4.0],
-                value=['zero', 'one', 'two', 'three'],
-                confidence=[0.1, 0.9, 0.9, 0.9])
+    data = dict(time=[4.0, 5.0, 5.0, 5.0, 10.0],
+                duration=[1.0, 0.0, 2.0, 4.0, 4.0],
+                value=['none', 'zero', 'one', 'two', 'three'],
+                confidence=[1, 0.1, 0.9, 0.9, 0.9])
     ann = jams.Annotation(namespace, data=data, time=5.0, duration=10.0)
 
-    ann_trim = ann.trim(0, 8, strict=False)
+    ann_trim = ann.trim(1, 8, strict=False)
 
     assert ann_trim.time == 5
     assert ann_trim.duration == 3
-    assert ann_trim.sandbox.trim == [{'start_time': 0, 'end_time': 8,
+    assert ann_trim.sandbox.trim == [{'start_time': 1, 'end_time': 8,
                                       'trim_start': 5, 'trim_end': 8}]
     assert ann_trim.namespace == ann.namespace
     assert ann_trim.annotation_metadata == ann.annotation_metadata
@@ -826,11 +826,11 @@ def test_annotation_trim_partial_overlap_beginning():
     assert ann_trim.data == expected_ann.data
 
     # strict=True
-    ann_trim = ann.trim(0, 8, strict=True)
+    ann_trim = ann.trim(1, 8, strict=True)
 
     assert ann_trim.time == 5
     assert ann_trim.duration == 3
-    assert ann_trim.sandbox.trim == [{'start_time': 0, 'end_time': 8,
+    assert ann_trim.sandbox.trim == [{'start_time': 1, 'end_time': 8,
                                       'trim_start': 5, 'trim_end': 8}]
     assert ann_trim.namespace == ann.namespace
     assert ann_trim.annotation_metadata == ann.annotation_metadata

--- a/tests/test_jams.py
+++ b/tests/test_jams.py
@@ -801,10 +801,10 @@ def test_annotation_trim_partial_overlap_beginning():
     # range: at the beginning
     # strict=False
     namespace = 'tag_open'
-    data = dict(time=[5.0, 5.0, 10.0],
-                duration=[2.0, 4.0, 4.0],
-                value=['one', 'two', 'three'],
-                confidence=[0.9, 0.9, 0.9])
+    data = dict(time=[5.0, 5.0, 5.0, 10.0],
+                duration=[0.0, 2.0, 4.0, 4.0],
+                value=['zero', 'one', 'two', 'three'],
+                confidence=[0.1, 0.9, 0.9, 0.9])
     ann = jams.Annotation(namespace, data=data, time=5.0, duration=10.0)
 
     ann_trim = ann.trim(0, 8, strict=False)
@@ -816,10 +816,10 @@ def test_annotation_trim_partial_overlap_beginning():
     assert ann_trim.namespace == ann.namespace
     assert ann_trim.annotation_metadata == ann.annotation_metadata
 
-    expected_data = dict(time=[5.0, 5.0],
-                         duration=[2.0, 3.0],
-                         value=['one', 'two'],
-                         confidence=[0.9, 0.9])
+    expected_data = dict(time=[5.0, 5.0, 5.0],
+                         duration=[0.0, 2.0, 3.0],
+                         value=['zero', 'one', 'two'],
+                         confidence=[0.1, 0.9, 0.9])
     expected_ann = jams.Annotation(namespace, data=expected_data, time=5.0,
                                    duration=3.0)
 
@@ -835,10 +835,10 @@ def test_annotation_trim_partial_overlap_beginning():
     assert ann_trim.namespace == ann.namespace
     assert ann_trim.annotation_metadata == ann.annotation_metadata
 
-    expected_data = dict(time=[5.0],
-                         duration=[2.0],
-                         value=['one'],
-                         confidence=[0.9])
+    expected_data = dict(time=[5.0, 5.0],
+                         duration=[0.0, 2.0],
+                         value=['zero', 'one'],
+                         confidence=[0.1, 0.9])
     expected_ann = jams.Annotation(namespace, data=expected_data, time=5.0,
                                    duration=3.0)
 


### PR DESCRIPTION
This PR fixes #203 by including observations which have end time coincident with the trimming start time.

I'm still not 100% sure this is completely correct.  It works for @tomxi's example case, where there was a time=0, duration=0 observation being trimmed to start at 0.  This should clearly be included.

However, if we have an observation `[2, 2+1)` with a trim of `[3, 10)`, the modified logic will allow it to pass through, when it probably shouldn't, since `[2, 3) ∩ [3, 10) = {}`.  The ambiguity here comes from our special-case handling of duration-0 observations, which we treat as closed intervals to allow a (Nyquist-style) sampling interpretation.

Perhaps we should explicitly handle this case, by only allowing the boundary condition `end_time >= trim_start` if the observation duration is 0?