### PR TITLE
Allow to change the default indentation of the produced JSON.

### DIFF
--- a/jams/core.py
+++ b/jams/core.py
@@ -1741,7 +1741,7 @@ class JAMS(JObject):
 
         return self.annotations.search(**kwargs)
 
-    def save(self, path_or_file, strict=True, fmt='auto'):
+    def save(self, path_or_file, strict=True, fmt='auto', indent=2):
         """Serialize annotation as a JSON formatted stream to file.
 
         Parameters
@@ -1762,6 +1762,14 @@ class JAMS(JObject):
             If the input is an open file handle, `jams` encoding
             is used.
 
+        indent : int
+            If a non-negative integer, then JSON array elements and
+            object members will be pretty-printed with that indent level. An indent
+            level of 0 will only insert newlines. `None` is the most compact
+            representation.
+
+            By default, 2 is used.
+
 
         Raises
         ------
@@ -1777,7 +1785,7 @@ class JAMS(JObject):
         self.validate(strict=strict)
 
         with _open(path_or_file, mode='w', fmt=fmt) as fdesc:
-            json.dump(self.__json__, fdesc, indent=2)
+            json.dump(self.__json__, fdesc, indent=indent)
 
     def validate(self, strict=True):
         '''Validate a JAMS object against the schema.

--- a/tests/test_jams.py
+++ b/tests/test_jams.py
@@ -444,9 +444,10 @@ def input_jam():
     return jams.load('tests/fixtures/valid.jams')
 
 
-def test_jams_save(input_jam, output_path):
+@parametrize('indent', [None, 0, 1, 2])
+def test_jams_save(input_jam, output_path, indent):
 
-    input_jam.save(output_path)
+    input_jam.save(output_path, indent=indent)
     reload_jam = jams.load(output_path)
     assert input_jam == reload_jam
 


### PR DESCRIPTION
The default is 2, which can lead to fairly large bloat, when considering ten-thousands of JAMS (think global tempo estimates like https://github.com/tempoeval/tempo_eval/tree/main/annotations). Of course one can go the gzip/jamz route, which will create smaller files, but at the price of (easy/casual) editability.

Being able to simple pass indent=None is a compromise. It still allows manual editing, while also reducing size quite a bit.