### PR TITLE
Fix Python 3.4 CI Build

### DIFF
--- a/.travis_dependencies.sh
+++ b/.travis_dependencies.sh
@@ -30,6 +30,8 @@ if [ ! -d "$src" ]; then
         export PATH="$src/bin:$PATH"
         conda_create 
         source activate $ENV_NAME
+        # later versions than 5.2 do not support python 3.4 anymore
+        pip install PyYAML==5.2; python_version==3.4
         pip install python-coveralls
         source deactivate
     popd

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'pandas',
         'sortedcontainers>=2.0.0',
-        'pyrsistent<0.15: python_version=="3.4"',
+        'pyrsistent<0.15; python_version=="3.4"',
         'jsonschema>=3.0.0',
         'numpy>=1.8.0',
         'six',

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     install_requires=[
         'pandas',
         'sortedcontainers>=2.0.0',
+        'pyrsistent<0.15: python_version=="3.4"',
         'jsonschema>=3.0.0',
         'numpy>=1.8.0',
         'six',


### PR DESCRIPTION
The CI build for Python 3.4 currently fails, because some used libraries (PyYAML, pyrsistent) have stopped supporting Python 3.4. This PR fixes the build by requiring older versions of said libraries when using Python 3.4.
