### PR TITLE
Migrate deprecated imp package to importlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,18 @@
 from setuptools import setup, find_packages
 
-import imp
+import importlib.util
+import importlib.machinery
 
-version = imp.load_source('jams.version', 'jams/version.py')
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+version = load_source('jams.version', 'jams/version.py')
 
 setup(
     name='jams',


### PR DESCRIPTION
This PR fixes #214 by migrating from `imp` to `importlib`.