### PR TITLE
np.float_ -> np.float64

### DIFF
--- a/jams/schema.py
+++ b/jams/schema.py
@@ -190,11 +190,11 @@ def list_namespaces():
 # Mapping of js primitives to numpy types
 __TYPE_MAP__ = dict(integer=np.int_,
                     boolean=np.bool_,
-                    number=np.float_,
+                    number=np.float64,
                     object=np.object_,
                     array=np.object_,
                     string=np.object_,
-                    null=np.float_)
+                    null=np.float64)
 
 
 def __get_dtype(typespec):


### PR DESCRIPTION
Hi all!
I tried to use mirdata with Python 3.10+ and jams was throwing an error regarding `np.float_`, so this PR changes that whenever it is necessary.

After doing the changes, I installed the library locally and had no problem with mirdata anymore. 
I was not able to run the tests though. It seems that [nose is unmaintained and not supported for Python 3.10+](https://github.com/SyneRBI/SIRF/issues/1148), so I'm not sure how to proceed here.