### PR TITLE
Update import imp to import importlib

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,8 +72,20 @@ copyright = u'2015, JAMS development team'
 # built documents.
 #
 # The short X.Y version.
-import imp
-jams_version = imp.load_source('jams.version', '../jams/version.py')
+import importlib.util
+import importlib.machinery
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
+
+jams_version = load_source('jams.version', '../jams/version.py')
 version = jams_version.short_version
 # The full version, including alpha/beta/rc tags.
 release = jams_version.version


### PR DESCRIPTION
The update changing import imp to import importlib.util and import importlib.machinery and inclusion of a custom function are as recommended in the Python documentation: https://docs.python.org/3/whatsnew/3.12.html#imp . It may be preferable to include this function in a helpers.py or something like that..

Testing these changes the package installs successfully calling python setup.py install .
