### PR TITLE
Remove imp module import.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,8 +72,11 @@ copyright = u'2015, JAMS development team'
 # built documents.
 #
 # The short X.Y version.
-import imp
-jams_version = imp.load_source('jams.version', '../jams/version.py')
+from importlib.util import spec_from_file_location, module_from_spec
+spec = spec_from_file_location('jams.version', '../jams/version.py')
+jams_version = module_from_spec(spec)
+spec.loader.exec_module(jams_version)
+
 version = jams_version.short_version
 # The full version, including alpha/beta/rc tags.
 release = jams_version.version


### PR DESCRIPTION
Newer python installations fail installation of jams due to depreciated module imp. This PR updates the to the newer syntax with importlib.

Clean installation tested on all supported versions of python. Slightly simpler than #224 and related to ticket #223.

for v in 3.9 3.10 3.11 3.12 3.13 ; do uv venv --python $v ;. .venv/bin/activate; uv pip install git+https://github.com/quadrater/jams; deactivate; done
Using CPython 3.9.23
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
Resolved 17 packages in 189ms
Installed 17 packages in 97ms
 + attrs==25.3.0
 + decorator==5.2.1
 + jams==0.3.5a0 (from git+https://github.com/quadrater/jams@90ad72b8dcafa91f2f9cb1c0ff827c24bf5ee9de)
 + jsonschema==4.24.0
 + jsonschema-specifications==2025.4.1
 + mir-eval==0.8.2
 + numpy==2.0.2
 + pandas==2.3.0
 + python-dateutil==2.9.0.post0
 + pytz==2025.2
 + referencing==0.36.2
 + rpds-py==0.25.1
 + scipy==1.13.1
 + six==1.17.0
 + sortedcontainers==2.4.0
 + typing-extensions==4.14.0
 + tzdata==2025.2
Using CPython 3.10.17 interpreter at: /usr/bin/python3.10
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
Resolved 17 packages in 137ms
Installed 17 packages in 114ms
 + attrs==25.3.0
 + decorator==5.2.1
 + jams==0.3.5a0 (from git+https://github.com/quadrater/jams@90ad72b8dcafa91f2f9cb1c0ff827c24bf5ee9de)
 + jsonschema==4.24.0
 + jsonschema-specifications==2025.4.1
 + mir-eval==0.8.2
 + numpy==2.2.6
 + pandas==2.3.0
 + python-dateutil==2.9.0.post0
 + pytz==2025.2
 + referencing==0.36.2
 + rpds-py==0.25.1
 + scipy==1.15.3
 + six==1.17.0
 + sortedcontainers==2.4.0
 + typing-extensions==4.14.0
 + tzdata==2025.2
Using CPython 3.11.12 interpreter at: /usr/bin/python3.11
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
Resolved 17 packages in 84ms
Installed 17 packages in 118ms
 + attrs==25.3.0
 + decorator==5.2.1
 + jams==0.3.5a0 (from git+https://github.com/quadrater/jams@90ad72b8dcafa91f2f9cb1c0ff827c24bf5ee9de)
 + jsonschema==4.24.0
 + jsonschema-specifications==2025.4.1
 + mir-eval==0.8.2
 + numpy==2.3.0
 + pandas==2.3.0
 + python-dateutil==2.9.0.post0
 + pytz==2025.2
 + referencing==0.36.2
 + rpds-py==0.25.1
 + scipy==1.15.3
 + six==1.17.0
 + sortedcontainers==2.4.0
 + typing-extensions==4.14.0
 + tzdata==2025.2
Using CPython 3.12.3 interpreter at: /usr/bin/python3.12
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
Resolved 17 packages in 85ms
Installed 17 packages in 94ms
 + attrs==25.3.0
 + decorator==5.2.1
 + jams==0.3.5a0 (from git+https://github.com/quadrater/jams@90ad72b8dcafa91f2f9cb1c0ff827c24bf5ee9de)
 + jsonschema==4.24.0
 + jsonschema-specifications==2025.4.1
 + mir-eval==0.8.2
 + numpy==2.3.0
 + pandas==2.3.0
 + python-dateutil==2.9.0.post0
 + pytz==2025.2
 + referencing==0.36.2
 + rpds-py==0.25.1
 + scipy==1.15.3
 + six==1.17.0
 + sortedcontainers==2.4.0
 + typing-extensions==4.14.0
 + tzdata==2025.2
Using CPython 3.13.4
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
Resolved 16 packages in 81ms
Installed 16 packages in 98ms
 + attrs==25.3.0
 + decorator==5.2.1
 + jams==0.3.5a0 (from git+https://github.com/quadrater/jams@90ad72b8dcafa91f2f9cb1c0ff827c24bf5ee9de)
 + jsonschema==4.24.0
 + jsonschema-specifications==2025.4.1
 + mir-eval==0.8.2
 + numpy==2.3.0
 + pandas==2.3.0
 + python-dateutil==2.9.0.post0
 + pytz==2025.2
 + referencing==0.36.2
 + rpds-py==0.25.1
 + scipy==1.15.3
 + six==1.17.0
 + sortedcontainers==2.4.0
 + tzdata==2025.2
